### PR TITLE
feat: Prepwork for repository renaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,17 @@ jobs:
     - npm run coverage
   - stage: deploy
     if: tag IS present
-    script:
-    - npm i -g now
-    - npm run deploy
-    - npm run alias
+    script: echo 'Deploying to NOW'
+    before_deploy: npm i now --no-save
+    deploy:
+      provider: script
+      skip_cleanup: true
+      script:
+      - npm run deploy
+      - npm run alias
+      on:
+        repo: windingtree/wt-read-api
+        tags: true
 env:
   global:
     secure: eQMrwJ4qlU76kI/a9cOoUYZZrDqL9PQ3BpbzQFDBnuPmcRYeMohaQo/JEv3lw3yrIHgNMEXvpwEUbjG0DoumuM7g8kVQCQ2rZZjvVspnTX+xWiF3YuIyb4fQGJL2g6YQDYjSlnYH+e4p3TrrjmQBHLc0VdFe04hkUcp4zCxYdKjFDRUpl2guqJWPMrCv3muh31jgnqlOCnTAI6GCcNAeuIXdfknNQRHdQ2z1YKH3Z24QS9TOiG+fTtlgKeKfOgs7Q3mnPlwcFUjAbpQn5jib490iMT1kQdPE09Jl1bUI2wdejXGTBHwEyr/zMm6I+ZYFld6FILKwadao+KwZRu8Ks/e5LIqM17KHhe2j5eALkEQwl91dUhdQm5aH6eKfUOA8yEfoYZhRjJiMK4QXb6mPDp1LdruErMe0qu+Y7JHPAb2km8HPpLDsOZglD9l+HPJpJ4iOCAgzr+AgawFStzZWEhWD+dlS3nhoFzJOldCVeaV2Bug3Jlr6Jl57i6QKOxKGck/v4Mep3871cfxbhik89YcR3c5YKcBrb3fx88dgjdP5kHzhL6TXgirL9ffBt6wFaZo8Qxlti6+jd+a8r6Lkop0Te899LVR5R7dF2TrkmqMwBtgd7fDaazODlN5bQoFefGyihIUIwQQ2yVjETPeIUdKGhiLM9hbUlCQoPQ/lkEM=

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-# WT NodeJS API
+# WT Read API
 API written in nodejs to fetch information from the Winding Tree platform.
 
 ## Requirements
@@ -8,7 +8,7 @@ API written in nodejs to fetch information from the Winding Tree platform.
 ### Getting stared
 In order to install and run tests, we must:
 ```
-git clone git@github.com:windingtree/wt-nodejs-api.git
+git clone git@github.com:windingtree/wt-read-api.git
 nvm install
 npm install
 npm test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wt-nodejs-api",
+  "name": "wt-read-api",
   "version": "0.1.1",
   "description": " API to interact with the Winding Tree platform",
   "main": "index.js",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/windingtree/wt-nodejs-api.git"
+    "url": "git+https://github.com/windingtree/wt-read-api.git"
   },
   "keywords": [
     "winding-tree",
@@ -26,9 +26,9 @@
   "author": "WT Dev Team <support@winidngtree.com>",
   "license": "APACHE 2.0",
   "bugs": {
-    "url": "https://github.com/windingtree/wt-nodejs-api/issues"
+    "url": "https://github.com/windingtree/wt-read-api/issues"
   },
-  "homepage": "https://github.com/windingtree/wt-nodejs-api#readme",
+  "homepage": "https://github.com/windingtree/wt-read-api#readme",
   "dependencies": {
     "@windingtree/off-chain-adapter-http": "^2.0.0",
     "@windingtree/off-chain-adapter-in-memory": "^3.1.1",

--- a/src/app.js
+++ b/src/app.js
@@ -21,8 +21,8 @@ app.use(hotelsRouter);
 // Root handler
 app.get('/', (req, res) => {
   const response = {
-    docs: 'https://github.com/windingtree/wt-nodejs-api/blob/master/README.md',
-    info: 'https://github.com/windingtree/wt-nodejs-api',
+    docs: 'https://github.com/windingtree/wt-read-api/blob/master/README.md',
+    info: 'https://github.com/windingtree/wt-read-api',
     version,
   };
   res.status(200).json(response);


### PR DESCRIPTION
This PR replaces all occurrences of `wt-nodejs-api` with `wt-read-api` in anticipation of repository renaming which will happen before the next pinned version (hopefully sometimes next week).