### PR TITLE
fix: CORS + whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@windingtree/off-chain-adapter-swarm": "^3.1.0",
     "@windingtree/wt-js-libs": "^0.2.7",
     "body-parser": "^1.18.3",
+    "cors": "^2.8.4",
     "express": "^4.16.3",
     "express-rate-limit": "^2.11.0",
     "lodash": "^4.17.10",

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const swaggerUi = require('swagger-ui-express');
 const morgan = require('morgan');
+const cors = require('cors');
 const YAML = require('yamljs');
 const app = express();
 const config = require('./config');
@@ -19,8 +20,9 @@ const swaggerDocument = YAML.load(path.resolve('./docs/swagger.yaml'));
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Generic middlewares
-
+app.use(cors());
 app.use(bodyParser.json());
+
 // Logging only when not in test mode
 if (config.logHttpTraffic) {
   app.use(morgan(':remote-addr :remote-user [:date[clf]] :method :url HTTP/:http-version :status :res[content-length] - :response-time ms', {

--- a/src/app.js
+++ b/src/app.js
@@ -9,7 +9,6 @@ const app = express();
 const config = require('./config');
 const { version } = require('../package.json');
 
-const { validateIPWhiteList } = require('./middlewares');
 const { hotelsRouter } = require('./routes/hotels');
 const { handleApplicationError } = require('./errors');
 
@@ -39,7 +38,6 @@ if (config.logHttpTraffic) {
     stream: process.stdout,
   }));
 }
-app.use('/*', validateIPWhiteList);
 
 // Router
 

--- a/src/config/local.js
+++ b/src/config/local.js
@@ -36,7 +36,6 @@ module.exports = {
       },
     },
   }),
-  whiteList: [],
   networkSetup: async (currentConfig) => {
     currentConfig.wtIndexAddress = (await deployIndex()).address;
   },

--- a/src/config/ropsten.js
+++ b/src/config/ropsten.js
@@ -29,7 +29,6 @@ module.exports = {
       },
     },
   }),
-  whiteList: [],
   logHttpTraffic: true,
   logger: winston.createLogger({
     level: 'debug',

--- a/src/config/test.js
+++ b/src/config/test.js
@@ -21,9 +21,6 @@ module.exports = {
       },
     },
   }),
-  whiteList: [
-    '127.0.0.1',
-  ],
   logHttpTraffic: false,
   logger: winston.createLogger({
     level: 'debug',

--- a/src/errors/codes.js
+++ b/src/errors/codes.js
@@ -17,11 +17,6 @@ module.exports = {
     status: 502,
     short: 'Hotel data is not accessible',
   },
-  whiteList: {
-    status: 403,
-    short: 'IP is not whitelisted.',
-    long: 'IP must be in the whitelist. Please contact the administrator.',
-  },
   rateLimit: {
     status: 429,
     short: 'API rate Limit Exceeded',

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -1,6 +1,5 @@
 const wtJsLibs = require('../services/wt-js-libs');
 const { handleApplicationError } = require('../errors');
-const config = require('../config');
 
 const injectWtLibs = async (req, res, next) => {
   if (res.locals.wt) {
@@ -11,26 +10,6 @@ const injectWtLibs = async (req, res, next) => {
     instance: wtLibsInstance,
     index: await wtJsLibs.getWTIndex(),
   };
-  next();
-};
-
-const validateIPWhiteList = function (req, res, next) {
-  const whiteList = config.whiteList;
-  if (!whiteList.length) {
-    return next();
-  }
-  let ip = req.ip ||
-            req.headers['x-forwarded-for'] ||
-            req.connection.remoteAddress ||
-            req.socket.remoteAddress ||
-            req.connection.socket.remoteAddress;
-
-  if (ip.substr(0, 7) === '::ffff:') {
-    ip = ip.substr(7);
-  }
-  if (whiteList.indexOf(ip) === -1) {
-    return next(handleApplicationError('whiteList', new Error()));
-  }
   next();
 };
 
@@ -46,6 +25,5 @@ const validateHotelAddress = (req, res, next) => {
 
 module.exports = {
   injectWtLibs,
-  validateIPWhiteList,
   validateHotelAddress,
 };

--- a/test/controllers/api.spec.js
+++ b/test/controllers/api.spec.js
@@ -54,21 +54,4 @@ describe('API', function () {
       })
       .expect(404);
   });
-
-  it('GET with not whitelisted ip. Expect #whiteList', async () => {
-    config.whiteList = ['11.22.33.44'];
-    await request(server)
-      .get('/')
-      .expect((res) => {
-        expect(res.body).to.have.property('code', '#whiteList');
-      })
-      .expect(403);
-  });
-
-  it('Allow all ips with empty whiteList', async () => {
-    config.whiteList = [];
-    await request(server)
-      .get('/')
-      .expect(200);
-  });
 });

--- a/test/controllers/api.spec.js
+++ b/test/controllers/api.spec.js
@@ -26,6 +26,15 @@ describe('API', function () {
       .expect(200);
   });
 
+  it('should respond with CORS headers', async () => {
+    await request(server)
+      .get('/')
+      .expect((res) => {
+        expect(res.headers).to.have.property('access-control-allow-origin', '*');
+      })
+      .expect(200);
+  });
+
   it('GET /docs', async () => {
     await request(server)
       .get('/docs/')


### PR DESCRIPTION
API now returns `Access-control-allow-origin: *`. I've also dropped the IP whitelist filter, because it really does not make sense to have it alongside the very permissive CORS settings.