### PR TITLE
docs: Adds an initialized demo account to local dev-net

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ step if you have a different network already running.
 npm run dev-net
 ```
 
+If you need to interact (for example add some testing hotels) with the running dev-net
+in any way, you can use the Winding Tree demo wallet protected by password `windingtree`.
+It is initialized with enough ether. For sample interaction scripts, check out our
+[Developer guides](https://github.com/windingtree/wiki/tree/master/developer-guides).
+
+**!!!NEVER USE THIS WALLET FOR ANYTHING IN PRODUCTION!!!** Anyone has access to it.
+
+```js
+{"version":3,"id":"7fe84016-4686-4622-97c9-dc7b47f5f5c6","address":"d037ab9025d43f60a31b32a82e10936f07484246","crypto":{"ciphertext":"ef9dcce915eeb0c4f7aa2bb16b9ae6ce5a4444b4ed8be45d94e6b7fe7f4f9b47","cipherparams":{"iv":"31b12ef1d308ea1edacc4ab00de80d55"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"d06ccd5d9c5d75e1a66a81d2076628f5716a3161ca204d92d04a42c057562541","n":8192,"r":8,"p":1},"mac":"2c30bc373c19c5b41385b85ffde14b9ea9f0f609c7812a10fdcb0a565034d9db"}};
+```
+
 Now we can run our dev server.
 ```bash
 npm run dev

--- a/scripts/dev-net.sh
+++ b/scripts/dev-net.sh
@@ -7,39 +7,41 @@ set -o errexit
 trap cleanup EXIT
 
 cleanup() {
-  # Kill the testrpc instance that we started (if we started one and if it's still running).
-  if [ -n "$testrpc_pid" ] && ps -p $testrpc_pid > /dev/null; then
-    kill -9 $testrpc_pid
+  # Kill the ganache instance that we started (if we started one and if it's still running).
+  if [ -n "$ganache_pid" ] && ps -p $ganache_pid > /dev/null; then
+    kill -9 $ganache_pid
   fi
 }
 
-testrpc_port=8545
+ganache_port=8545
 
-testrpc_running() {
-  nc -z localhost "$testrpc_port"
+ganache_running() {
+  nc -z localhost "$ganache_port"
 }
 
-start_testrpc() {
+start_ganache() {
   # We define 2 accounts, DAO and default Hotel Manager
   # with balance lots of ether, needed for high-value tests.
   # Available Accounts - on a clean network
   # =======================================
   # (0) 0x87265a62c60247f862b9149423061b36b460f4bb
   # (1) 0xb99c958777f024bc4ce992b2a0efb2f1f50a4dcf
+  # (2) 0xD037aB9025d43f60a31b32A82E10936f07484246
   #
   local accounts=(
     --account="0xe8280389ca1303a2712a874707fdd5d8ae0437fab9918f845d26fd9919af5a92,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
     --account="0xa4605db83bb3e663f33fb92542ca38344bd8d1bf2d07cc6cc908fec87b7674d5,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    --account="0x4259ac86777aa87b3e24006fe6bc98a9c726c3618b18541716a8acc1a7161fa2,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
   )
 
   node_modules/.bin/ganache-cli -i 77 --gasLimit 6000000 "${accounts[@]}"
-  testrpc_pid=$!
+  ganache_pid=$!
   sleep 1
 }
 
-if testrpc_running; then
-  echo "Using existing testrpc instance"
+if ganache_running; then
+  echo "Using existing ganache instance"
 else
-  echo "Starting our own testrpc instance"
-  start_testrpc
+  echo "Starting our own ganache instance"
+  start_ganache
 fi

--- a/scripts/local-network.js
+++ b/scripts/local-network.js
@@ -1,9 +1,8 @@
 const TruffleContract = require('truffle-contract');
 const Web3 = require('web3');
 const WTIndexContract = require('@windingtree/wt-contracts/build/contracts/WTIndex');
-const config = require('../src/config');
 
-const provider = new Web3.providers.HttpProvider(config.web3Provider);
+const provider = new Web3.providers.HttpProvider('http://localhost:8545');
 const web3 = new Web3(provider);
 
 // dirty hack for web3@1.0.0 support for localhost testrpc, see

--- a/src/config/local.js
+++ b/src/config/local.js
@@ -5,6 +5,17 @@ const HttpAdapter = require('@windingtree/off-chain-adapter-http');
 const { deployIndex } = require('../../scripts/local-network');
 
 const winston = require('winston');
+
+const logger = winston.createLogger({
+  level: 'debug',
+  transports: [
+    new winston.transports.Console({
+      format: winston.format.simple(),
+      handleExceptions: true,
+    }),
+  ],
+});
+
 module.exports = {
   port: 3000,
   baseUrl: 'http://localhost:3000',
@@ -38,15 +49,8 @@ module.exports = {
   }),
   networkSetup: async (currentConfig) => {
     currentConfig.wtIndexAddress = (await deployIndex()).address;
+    logger.info(`Winding Tree index deployed to ${currentConfig.wtIndexAddress}`);
   },
   logHttpTraffic: true,
-  logger: winston.createLogger({
-    level: 'debug',
-    transports: [
-      new winston.transports.Console({
-        format: winston.format.simple(),
-        handleExceptions: true,
-      }),
-    ],
-  }),
+  logger: logger
 };


### PR DESCRIPTION
The intention of this PR is to provide an easiest way of running the API locally. But it doesn't really make sense to use it without hotels, and in order to deploy hotels, you need to have an account with enough Ether. So I have re-used the wallet shown in multiple places as Winding Tree demo wallet that is initialized with lots of Ether during the dev-net startup.

I've also dropped an unused configuration option. I have no idea how it could have been working.