### PR TITLE
chore: Release 0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wt-read-api",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wt-read-api",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": " API to interact with the Winding Tree platform",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "start": "node ./src/index.js",
     "dev": "WT_CONFIG=dev npm start",
-    "deploy": "now -e NODE_ENV=production --token $NOW_TOKEN --docker --public",
+    "deploy": "now -e NODE_ENV=production --team windingtree --token $NOW_TOKEN --docker --public",
     "alias": "now alias --token=$NOW_TOKEN",
     "dev-net": "./scripts/dev-net.sh"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node ./src/index.js",
     "dev": "WT_CONFIG=dev npm start",
     "deploy": "now -e NODE_ENV=production --team windingtree --token $NOW_TOKEN --docker --public",
-    "alias": "now alias --token=$NOW_TOKEN",
+    "alias": "now alias --team windingtree --token=$NOW_TOKEN",
     "dev-net": "./scripts/dev-net.sh"
   },
   "repository": {

--- a/src/config/ropsten.js
+++ b/src/config/ropsten.js
@@ -3,7 +3,7 @@ const SwarmAdapter = require('@windingtree/off-chain-adapter-swarm');
 const HttpAdapter = require('@windingtree/off-chain-adapter-http');
 
 module.exports = {
-  wtIndexAddress: '0x407f550023eb6ad8a4797844489e17c5ced17e06',
+  wtIndexAddress: '0x933198455e38925bccb4bfe9fb59bac31d00b4d3',
   port: 3000,
   baseUrl: process.env.BASE_URL || 'https://demo-api.windingtree.com',
   wtLibs: WtJsLibs.createInstance({


### PR DESCRIPTION
**After deployment, it will point to WTIndex@0.2.4 at 0x933198455e38925bccb4bfe9fb59bac31d00b4d3 on Ropsten**

- Merge this PR with a merge commit.
- Manually tag the resulting merge commit with v0.2.5 and push it to github.
- Travis makes a release from a tagged commit.
- Don't delete the develop branch!