### PR TITLE
feat: Makes fields query param resolution more granular

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,10 @@
 const DEFAULT_HOTEL_FIELDS = 'id,location,name,description,contacts,address,currency,images,amenities,updatedAt';
 const DEFAULT_HOTELS_FIELDS = 'id,location,name';
 
-const OBLIGATORY_FIELDS = ['id'];
+const HOTEL_FIELDS = [
+  'manager',
+];
+
 const DESCRIPTION_FIELDS = [
   'name',
   'description',
@@ -16,16 +19,10 @@ const DESCRIPTION_FIELDS = [
   'updatedAt',
 ];
 
-const HOTEL_FIELDS = [
-  'manager',
-  'id',
-];
-
 const DEFAULT_PAGE_SIZE = 30;
 const MAX_PAGE_SIZE = 300;
 
 module.exports = {
-  OBLIGATORY_FIELDS,
   DESCRIPTION_FIELDS,
   HOTEL_FIELDS,
   DEFAULT_HOTELS_FIELDS,

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -24,9 +24,10 @@ const {
 // Helpers
 const flattenObject = (contents, fields) => {
   let currentFieldDef = {},
-    currentLevelName, remainingPath,
+    currentLevelName,
     result = {};
   for (let field of fields) {
+    let remainingPath;
     if (field.indexOf('.') === -1) {
       currentLevelName = field;
     } else {
@@ -78,9 +79,9 @@ const resolveHotelObject = async (hotel, fields) => {
   let plainHotel;
   try {
     if (fields.length) {
-      plainHotel = hotel.toPlainObject(fields);
+      plainHotel = await hotel.toPlainObject(fields);
     } else {
-      plainHotel = hotel.toPlainObject();
+      plainHotel = await hotel.toPlainObject();
     }
   } catch (e) {
     let message = 'Cannot get hotel data';
@@ -98,10 +99,10 @@ const resolveHotelObject = async (hotel, fields) => {
       },
     };
   }
-  const flattenedOffChainData = (flattenObject((await plainHotel).dataUri.contents, fields));
+  const flattenedOffChainData = (flattenObject(plainHotel.dataUri.contents, fields));
   return mapHotelObjectToResponse({
     ...flattenedOffChainData.descriptionUri,
-    ...(flattenObject(await plainHotel, fields)),
+    ...(flattenObject(plainHotel, fields)),
     id: hotel.address,
   });
 };

--- a/src/services/property-mapping.js
+++ b/src/services/property-mapping.js
@@ -6,6 +6,11 @@ const mapHotelObjectToResponse = (hotel) => {
   return Object.keys(hotel).reduce((newHotel, field) => {
     const newField = hotelMapping[field] || field;
     newHotel[newField] = hotel[field];
+    if (field === 'roomTypes') {
+      for (let roomTypeId in hotel[field]) {
+        newHotel[field][roomTypeId].id = roomTypeId;
+      }
+    }
     return newHotel;
   }, {});
 };


### PR DESCRIPTION
I've rewritten the resolution of `fields` query attribute to fully utilize the `toPlainObject` feature of the hotel. This brought up a small benefit of being able to resolve even nested fields, such as `address.postalCode` or `roomTypes.name`.

It's not very thoroughly tested and there might be some edge cases that are not really covered or behave in a strange way. I consider this a stepping stone towards a generic solution that will come in handy once we add more off-chain documents.

It also doesn't seem to break anything.