### PR TITLE
feat: Only show the current API server in dynamically served docs.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ const { version } = require('../package.json');
 const { hotelsRouter } = require('./routes/hotels');
 
 const swaggerDocument = YAML.load(path.resolve('./docs/swagger.yaml'));
+swaggerDocument.servers = [{ url: config.baseUrl }];
 
 // No need to leak information and waste bandwith with this
 // header.


### PR DESCRIPTION
Fixes #155 