### PR TITLE
feat: Availability

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -55,7 +55,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: fields
           in: query
           description: >
@@ -113,7 +113,7 @@ paths:
                       Uri to next page of records. When there's no next page,
                       this is not set.
                     $ref: >-
-                      https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/UriType
+                      https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/UriType
         '400':
           $ref: '#/components/responses/InvalidRequestError'
         '500':
@@ -128,7 +128,7 @@ paths:
           description: Hotel Id as returned by `GET /hotel`
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: fields
           required: false
           in: query
@@ -186,7 +186,7 @@ paths:
           description: Hotel Id as returned by `GET /hotel`
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: fields
           in: query
           required: false
@@ -220,14 +220,14 @@ paths:
           description: Hotel Id as returned by `GET /hotel`
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: roomTypeId
           in: path
           required: true
           description: Id of room type
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/ObjectIdType
+              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType
         - name: fields
           in: query
           required: false
@@ -258,13 +258,13 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
         - name: roomTypeId
           in: path
           required: true
           description: Id of room type
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
       responses:
         '200':
           description: Rate plans for the room type
@@ -280,7 +280,7 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
       responses:
         '200':
           description: Rate plans for the hotel
@@ -297,13 +297,13 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
         - name: ratePlanId
           in: path
           required: true
           description: Id of rate plan
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
       responses:
         '200':
           description: Rate plan details
@@ -351,27 +351,27 @@ components:
             identifies the errorring record.
     HotelListItem:
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/HotelDescriptionBase'
+        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/HotelDescriptionBase'
         - type: object
           required:
           - id
           properties:
             id:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
             managerAddress:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
             roomTypes:
               description: Room types in the hotel
               $ref: '#/components/schemas/RoomTypesResponse'
     HotelDetail:
       allOf:
-      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/HotelDescription'
+      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/HotelDescription'
       - type: object
         properties:
           ratePlans:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/RatePlans'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/RatePlans'
           availability: 
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/Availability'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/Availability'
           roomTypes:
             description: Room types in the hotel
             $ref: '#/components/schemas/RoomTypesResponse'
@@ -383,16 +383,16 @@ components:
         $ref: '#/components/schemas/RoomTypeResponse'
     RoomTypeResponse:
       allOf:
-      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/RoomType'
+      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/RoomType'
       - type: object
         properties:
           id:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
             description: Vendor room type ID (should be unique for hotel)
           availability: 
             type: array
             items:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/AvailabilityForDay'
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilityForDay'
               
     RatePlansResponse:
       type: object
@@ -401,11 +401,11 @@ components:
         
     RatePlanResponse:
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/RatePlan'
+        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/RatePlan'
         - type: object
           properties:
             id:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
               description: Vendor rate plan ID (should be unique for hotel)
     Error:
       title: Error

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,7 +6,7 @@ servers:
     url: 'http://localhost:3000'
 info:
   description: API for reading hotels from WT
-  version: 1.0.1-rate-plans-2
+  version: 1.0.2
   title: WT reading
 paths:
   /:
@@ -163,6 +163,7 @@ paths:
                 - updatedAt
                 - cancellationPolicies
                 - ratePlans
+                - availability
       responses:
         '200':
           description: Hotel object
@@ -195,6 +196,7 @@ paths:
             type: string
             enum:
             - ratePlans
+            - availability
       responses:
         '200':
           description: Room types list
@@ -236,6 +238,7 @@ paths:
             type: string
             enum:
             - ratePlans
+            - availability
       responses:
         '200':
           description: Room type with id = `id`
@@ -251,7 +254,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   '/hotels/{hotelId}/roomTypes/{roomTypeId}/ratePlans':
     get:
-      summary: Get availability of the room type `id`
+      summary: Get rate plans of the room type `id`
       parameters:
         - name: hotelId
           in: path
@@ -272,6 +275,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RatePlansResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  '/hotels/{hotelId}/roomTypes/{roomTypeId}/availability':
+    get:
+      summary: Get availability of the room type `id`. The availability field contains only a single key with room type id.
+      parameters:
+        - name: hotelId
+          in: path
+          required: true
+          description: Hotel Id as returned by `GET /hotel`
+          schema:
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
+        - name: roomTypeId
+          in: path
+          required: true
+          description: Id of room type
+          schema:
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+      responses:
+        '200':
+          description: Availability for the room type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvailabilityResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  '/hotels/{hotelId}/availability':
+    get:
+      parameters:
+        - name: hotelId
+          in: path
+          required: true
+          description: Hotel Id as returned by `GET /hotel`
+          schema:
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
+      responses:
+        '200':
+          description: Availability data for the hotel
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvailabilityResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
   '/hotels/{hotelId}/ratePlans':
     get:
       parameters:
@@ -288,7 +336,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RatePlansResponse'
-                
+        '404':
+          $ref: '#/components/responses/NotFoundError'
   '/hotels/{hotelId}/ratePlans/{ratePlanId}':
     get:
       parameters:
@@ -311,6 +360,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RatePlanResponse'                
+        '404':
+          $ref: '#/components/responses/NotFoundError'
 
 components:
   responses:
@@ -371,7 +422,7 @@ components:
           ratePlans:
             $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/RatePlans'
           availability: 
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/Availability'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
           roomTypes:
             description: Room types in the hotel
             $ref: '#/components/schemas/RoomTypesResponse'
@@ -390,9 +441,7 @@ components:
             $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
             description: Vendor room type ID (should be unique for hotel)
           availability: 
-            type: array
-            items:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilityForDay'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
               
     RatePlansResponse:
       type: object
@@ -407,6 +456,10 @@ components:
             id:
               $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
               description: Vendor rate plan ID (should be unique for hotel)
+
+    AvailabilityResponse:
+      $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
+
     Error:
       title: Error
       description: Default schema for errors returned by API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,21 @@
       "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
@@ -203,7 +218,7 @@
     },
     "@windingtree/lif-token": {
       "version": "0.1.2-erc827",
-      "resolved": "https://registry.npmjs.org/@windingtree/lif-token/-/lif-token-0.1.2-erc827.tgz",
+      "resolved": "http://registry.npmjs.org/@windingtree/lif-token/-/lif-token-0.1.2-erc827.tgz",
       "integrity": "sha512-JcAN3XPYwo0HAm8oR1nDL41qDIJxEDZS+5MvFTxUzwsfBK/fgYoV7zs8jBKBsmGAr694vv6oYgpFXv6ZBOxHGg==",
       "requires": {
         "abi-decoder": "^1.0.8",
@@ -332,13 +347,13 @@
       }
     },
     "@windingtree/wt-js-libs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@windingtree/wt-js-libs/-/wt-js-libs-0.3.0.tgz",
-      "integrity": "sha512-hD37vYCRsbN1eZOABk1Zpk1mamTlfd0lPz0HM7tz6P4BqgQMVMt/6W0+DcO6F/UJEndrl2yxH1kHIvzNKfdjxQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@windingtree/wt-js-libs/-/wt-js-libs-0.4.0.tgz",
+      "integrity": "sha512-U+8rSYTJc46sjI32VAi75VAayJ3fGv/HLqxqmrLa2pSceim3e5HxG//ivSw3ir2c9veTUOaNAS9bWqrnN9vyqw==",
       "requires": {
+        "@babel/runtime": "^7.0.0",
         "@windingtree/lif-token": "^0.1.2-erc827",
         "@windingtree/wt-contracts": "^0.2.4",
-        "babel-runtime": "^6.26.0",
         "bignumber.js": "^7.2.1",
         "lodash.clonedeep": "^4.5.0",
         "web3": "^1.0.0-beta.35"
@@ -7953,7 +7968,7 @@
         },
         "web3": {
           "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+          "resolved": "http://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
             "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@windingtree/off-chain-adapter-http": "^2.0.1",
     "@windingtree/off-chain-adapter-in-memory": "^4.0.0",
     "@windingtree/off-chain-adapter-swarm": "^3.2.0",
-    "@windingtree/wt-js-libs": "^0.3.0",
+    "@windingtree/wt-js-libs": "^0.4.0",
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "express": "^4.16.3",

--- a/scripts/local-network.js
+++ b/scripts/local-network.js
@@ -34,14 +34,20 @@ const deployIndex = async () => {
   });
 };
 
-const deployFullHotel = async (offChainDataAdapter, index, hotelDescription, ratePlans) => {
-  const descriptionUri = await offChainDataAdapter.upload(hotelDescription);
-  const ratePlansUri = await offChainDataAdapter.upload(ratePlans);
+const deployFullHotel = async (offChainDataAdapter, index, hotelDescription, ratePlans, availability) => {
   const accounts = await web3.eth.getAccounts();
-  const dataUri = await offChainDataAdapter.upload({
-    descriptionUri,
-    ratePlansUri,
-  });
+  const indexFile = {};
+
+  if (hotelDescription) {
+    indexFile['descriptionUri'] = await offChainDataAdapter.upload(hotelDescription);
+  }
+  if (ratePlans) {
+    indexFile['ratePlansUri'] = await offChainDataAdapter.upload(ratePlans);
+  }
+  if (availability) {
+    indexFile['availabilityUri'] = await offChainDataAdapter.upload(availability);
+  }
+  const dataUri = await offChainDataAdapter.upload(indexFile);
 
   const registerResult = await index.registerHotel(dataUri, {
     from: accounts[0],

--- a/src/controllers/availability.js
+++ b/src/controllers/availability.js
@@ -1,0 +1,18 @@
+const { Http404Error } = require('../errors');
+
+const findAll = async (req, res, next) => {
+  try {
+    let plainHotel = await res.locals.wt.hotel.toPlainObject(['availabilityUri']);
+    if (!plainHotel.dataUri.contents.availabilityUri) {
+      return next(new Http404Error('noAvailability', 'No availabilityUri specified.'));
+    }
+    let availability = plainHotel.dataUri.contents.availabilityUri.contents;
+    res.status(200).json(availability.latestSnapshot);
+  } catch (e) {
+    next(e);
+  }
+};
+
+module.exports = {
+  findAll,
+};

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -89,6 +89,9 @@ const resolveHotelObject = async (hotel, fields) => {
       if (flattenedOffChainData.ratePlansUri) {
         hotelData.ratePlans = flattenedOffChainData.ratePlansUri;
       }
+      if (flattenedOffChainData.availabilityUri) {
+        hotelData.availability = flattenedOffChainData.availabilityUri;
+      }
     } else {
       hotelData = {
         id: hotel.address,
@@ -128,6 +131,10 @@ const calculateFields = (fieldsQuery) => {
       }
 
       if (firstPart === 'ratePlansUri') {
+        return f;
+      }
+
+      if (firstPart === 'availabilityUri') {
         return f;
       }
 

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -90,7 +90,8 @@ const resolveHotelObject = async (hotel, fields) => {
         hotelData.ratePlans = flattenedOffChainData.ratePlansUri;
       }
       if (flattenedOffChainData.availabilityUri) {
-        hotelData.availability = flattenedOffChainData.availabilityUri;
+        // We intentionally move the data one level up
+        hotelData.availability = flattenedOffChainData.availabilityUri.latestSnapshot;
       }
     } else {
       hotelData = {

--- a/src/controllers/rate-plans.js
+++ b/src/controllers/rate-plans.js
@@ -7,6 +7,7 @@ const findAll = async (req, res, next) => {
     for (let ratePlanId in ratePlans) {
       ratePlans[ratePlanId].id = ratePlanId;
     }
+    // TODO handle hotels without rate plans uri
     res.status(200).json(ratePlans);
   } catch (e) {
     next(e);
@@ -23,6 +24,7 @@ const find = async (req, res, next) => {
       return next(new Http404Error('ratePlanNotFound', 'Rate plan not found'));
     }
     ratePlan.id = ratePlanId;
+    // TODO handle hotels without rate plans uri
     res.status(200).json(ratePlan);
   } catch (e) {
     next(e);

--- a/src/controllers/rate-plans.js
+++ b/src/controllers/rate-plans.js
@@ -3,11 +3,13 @@ const { Http404Error } = require('../errors');
 const findAll = async (req, res, next) => {
   try {
     let plainHotel = await res.locals.wt.hotel.toPlainObject(['ratePlansUri']);
+    if (!plainHotel.dataUri.contents.ratePlansUri) {
+      return next(new Http404Error('ratePlanNotFound', 'Rate plan not found'));
+    }
     let ratePlans = plainHotel.dataUri.contents.ratePlansUri.contents;
     for (let ratePlanId in ratePlans) {
       ratePlans[ratePlanId].id = ratePlanId;
     }
-    // TODO handle hotels without rate plans uri
     res.status(200).json(ratePlans);
   } catch (e) {
     next(e);
@@ -18,13 +20,15 @@ const find = async (req, res, next) => {
   let { ratePlanId } = req.params;
   try {
     let plainHotel = await res.locals.wt.hotel.toPlainObject(['ratePlansUri']);
+    if (!plainHotel.dataUri.contents.ratePlansUri) {
+      return next(new Http404Error('ratePlanNotFound', 'Rate plan not found'));
+    }
     const ratePlans = plainHotel.dataUri.contents.ratePlansUri.contents;
     let ratePlan = ratePlans[ratePlanId];
     if (!ratePlan) {
       return next(new Http404Error('ratePlanNotFound', 'Rate plan not found'));
     }
     ratePlan.id = ratePlanId;
-    // TODO handle hotels without rate plans uri
     res.status(200).json(ratePlan);
   } catch (e) {
     next(e);

--- a/src/controllers/room-types.js
+++ b/src/controllers/room-types.js
@@ -16,7 +16,9 @@ const detectAvailability = (roomTypeId, availabilityObject) => {
   let availability = availabilityObject && availabilityObject.latestSnapshot.availability[roomTypeId];
   return {
     updatedAt: availabilityObject && availabilityObject.latestSnapshot.updatedAt,
-    availability: availability || [],
+    availability: {
+      [roomTypeId]: availability || [],
+    },
   };
 };
 
@@ -41,6 +43,9 @@ const findAll = async (req, res, next) => {
       roomTypes[roomTypeId].id = roomTypeId;
       if (fieldsQuery.indexOf('ratePlans') > -1) {
         roomTypes[roomTypeId].ratePlans = detectRatePlans(roomTypeId, plainHotel.dataUri.contents.ratePlansUri.contents);
+      }
+      if (fieldsQuery.indexOf('availability') > -1) {
+        roomTypes[roomTypeId].availability = detectAvailability(roomTypeId, plainHotel.dataUri.contents.availabilityUri.contents);
       }
     }
     res.status(200).json(roomTypes);

--- a/src/controllers/room-types.js
+++ b/src/controllers/room-types.js
@@ -12,11 +12,22 @@ const detectRatePlans = (roomTypeId, ratePlansObject) => {
     }, {});
 };
 
+const detectAvailability = (roomTypeId, availabilityObject) => {
+  let availability = availabilityObject && availabilityObject.latestSnapshot.availability[roomTypeId];
+  return {
+    updatedAt: availabilityObject && availabilityObject.latestSnapshot.updatedAt,
+    availability: availability || [],
+  };
+};
+
 const getPlainHotel = async (hotel, fieldsQuery) => {
   fieldsQuery = fieldsQuery.filter((x) => !!x);
   const resolvedFields = ['descriptionUri.roomTypes'];
   if (fieldsQuery.indexOf('ratePlans') > -1) {
     resolvedFields.push('ratePlansUri');
+  }
+  if (fieldsQuery.indexOf('availability') > -1) {
+    resolvedFields.push('availabilityUri');
   }
   return hotel.toPlainObject(resolvedFields);
 };
@@ -52,6 +63,9 @@ const find = async (req, res, next) => {
     if (fieldsQuery.indexOf('ratePlans') > -1) {
       roomType.ratePlans = detectRatePlans(roomTypeId, plainHotel.dataUri.contents.ratePlansUri.contents);
     }
+    if (fieldsQuery.indexOf('availability') > -1) {
+      roomType.availability = detectAvailability(roomTypeId, plainHotel.dataUri.contents.availabilityUri.contents);
+    }
     res.status(200).json(roomType);
   } catch (e) {
     next(e);
@@ -69,8 +83,22 @@ const findRatePlans = async (req, res, next) => {
   }
 };
 
+const findAvailability = async (req, res, next) => {
+  let { roomTypeId } = req.params;
+  try {
+    let plainHotel = await res.locals.wt.hotel.toPlainObject(['availabilityUri']);
+    if (!plainHotel.dataUri.contents.availabilityUri) {
+      return next(new Http404Error('noAvailability', 'No availabilityUri specified.'));
+    }
+    res.status(200).json(detectAvailability(roomTypeId, plainHotel.dataUri.contents.availabilityUri.contents));
+  } catch (e) {
+    next(e);
+  }
+};
+
 module.exports = {
   findAll,
   find,
   findRatePlans,
+  findAvailability,
 };

--- a/src/controllers/room-types.js
+++ b/src/controllers/room-types.js
@@ -80,7 +80,16 @@ const find = async (req, res, next) => {
 const findRatePlans = async (req, res, next) => {
   let { roomTypeId } = req.params;
   try {
-    let plainHotel = await res.locals.wt.hotel.toPlainObject(['ratePlansUri']);
+    let plainHotel = await getPlainHotel(res.locals.wt.hotel, ['ratePlans']);
+    
+    let roomTypes = plainHotel.dataUri.contents.descriptionUri.contents.roomTypes;
+    let roomType = roomTypes[roomTypeId];
+    if (!roomType) {
+      return next(new Http404Error('roomTypeNotFound', 'Room type not found'));
+    }
+    if (!plainHotel.dataUri.contents.ratePlansUri) {
+      return next(new Http404Error('noRatePlans', 'No ratePlansUri specified.'));
+    }
     const ratePlans = detectRatePlans(roomTypeId, plainHotel.dataUri.contents.ratePlansUri.contents);
     res.status(200).json(ratePlans);
   } catch (e) {
@@ -91,7 +100,13 @@ const findRatePlans = async (req, res, next) => {
 const findAvailability = async (req, res, next) => {
   let { roomTypeId } = req.params;
   try {
-    let plainHotel = await res.locals.wt.hotel.toPlainObject(['availabilityUri']);
+    let plainHotel = await getPlainHotel(res.locals.wt.hotel, ['availability']);
+    
+    let roomTypes = plainHotel.dataUri.contents.descriptionUri.contents.roomTypes;
+    let roomType = roomTypes[roomTypeId];
+    if (!roomType) {
+      return next(new Http404Error('roomTypeNotFound', 'Room type not found'));
+    }
     if (!plainHotel.dataUri.contents.availabilityUri) {
       return next(new Http404Error('noAvailability', 'No availabilityUri specified.'));
     }

--- a/src/routes/hotels.js
+++ b/src/routes/hotels.js
@@ -9,15 +9,19 @@ const {
 const hotelsController = require('../controllers/hotels');
 const roomTypesController = require('../controllers/room-types');
 const ratePlansController = require('../controllers/rate-plans');
+const availabilityController = require('../controllers/availability');
 
 const hotelsRouter = express.Router();
 
 hotelsRouter.get('/hotels', injectWtLibs, hotelsController.findAll, handleOnChainErrors);
 hotelsRouter.get('/hotels/:hotelAddress', injectWtLibs, validateHotelAddress, resolveHotel, hotelsController.find, handleOnChainErrors);
 
+hotelsRouter.get('/hotels/:hotelAddress/availability', injectWtLibs, validateHotelAddress, resolveHotel, availabilityController.findAll, handleOnChainErrors, handleDataFetchingErrors);
+
 hotelsRouter.get('/hotels/:hotelAddress/roomTypes', injectWtLibs, validateHotelAddress, resolveHotel, roomTypesController.findAll, handleOnChainErrors, handleDataFetchingErrors);
 hotelsRouter.get('/hotels/:hotelAddress/roomTypes/:roomTypeId', injectWtLibs, validateHotelAddress, resolveHotel, roomTypesController.find, handleOnChainErrors, handleDataFetchingErrors);
 hotelsRouter.get('/hotels/:hotelAddress/roomTypes/:roomTypeId/ratePlans', injectWtLibs, validateHotelAddress, resolveHotel, roomTypesController.findRatePlans, handleOnChainErrors, handleDataFetchingErrors);
+hotelsRouter.get('/hotels/:hotelAddress/roomTypes/:roomTypeId/availability', injectWtLibs, validateHotelAddress, resolveHotel, roomTypesController.findAvailability, handleOnChainErrors, handleDataFetchingErrors);
 
 hotelsRouter.get('/hotels/:hotelAddress/ratePlans', injectWtLibs, validateHotelAddress, resolveHotel, ratePlansController.findAll, handleOnChainErrors, handleDataFetchingErrors);
 hotelsRouter.get('/hotels/:hotelAddress/ratePlans/:ratePlanId', injectWtLibs, validateHotelAddress, resolveHotel, ratePlansController.find, handleOnChainErrors, handleDataFetchingErrors);

--- a/src/services/property-mapping.js
+++ b/src/services/property-mapping.js
@@ -23,6 +23,7 @@ const mapHotelObjectToResponse = (hotel) => {
 const fieldMapping = {
   managerAddress: 'manager',
   ratePlans: 'ratePlansUri',
+  availability: 'availabilityUri',
 };
 
 const mapHotelFieldsFromQuery = (fields) => {

--- a/test/controllers/availability.spec.js
+++ b/test/controllers/availability.spec.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+const { expect } = require('chai');
+const web3 = require('web3');
+const request = require('supertest');
+const sinon = require('sinon');
+const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
+const {
+  deployIndex,
+  deployFullHotel,
+} = require('../../scripts/local-network');
+const {
+  HOTEL_DESCRIPTION,
+  RATE_PLANS,
+  AVAILABILITY,
+} = require('../utils/test-data');
+const {
+  FakeHotelWithBadOffChainData,
+} = require('../utils/fake-hotels');
+
+describe('Availability', function () {
+  let server;
+  let wtLibsInstance;
+  let address, indexContract;
+
+  beforeEach(async () => {
+    server = require('../../src/index');
+    const config = require('../../src/config');
+    wtLibsInstance = wtJsLibsWrapper.getInstance();
+    indexContract = await deployIndex();
+    config.wtIndexAddress = indexContract.address;
+    address = web3.utils.toChecksumAddress(await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY));
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  describe('GET /hotels/:hotelAddress/availability', () => {
+    it('should return availability', async () => {
+      await request(server)
+        .get(`/hotels/${address}/availability`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect((res) => {
+          expect(res.status).to.be.eql(200);
+          expect(res.body).to.eql(AVAILABILITY.latestSnapshot);
+        });
+    });
+
+    it('should return bad gateway for inaccessible data', async () => {
+      sinon.stub(wtJsLibsWrapper, 'getWTIndex').resolves({
+        getHotel: sinon.stub().resolves(new FakeHotelWithBadOffChainData()),
+      });
+      await request(server)
+        .get(`/hotels/${address}/availability`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect((res) => {
+          expect(res.status).to.be.eql(502);
+          wtJsLibsWrapper.getWTIndex.restore();
+        });
+    });
+
+    it('should return 404 if hotel has no availability', async () => {
+      let hotel = web3.utils.toChecksumAddress(await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS));
+      await request(server)
+        .get(`/hotels/${hotel}/availability`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(404);
+    });
+  });
+});

--- a/test/controllers/hotels.spec.js
+++ b/test/controllers/hotels.spec.js
@@ -448,7 +448,7 @@ describe('Hotels', function () {
             expect(res.body.roomTypes[roomType]).to.have.property('name');
             expect(res.body.roomTypes[roomType]).to.not.have.property('amenities');
           }
-          expect(res.body.availability).to.have.nested.property('latestSnapshot.updatedAt');
+          expect(res.body.availability).to.have.property('updatedAt');
         })
         .expect(200);
     });

--- a/test/controllers/rate-plans.spec.js
+++ b/test/controllers/rate-plans.spec.js
@@ -61,6 +61,15 @@ describe('Rate plans', function () {
           wtJsLibsWrapper.getWTIndex.restore();
         });
     });
+
+    it('should return 404 if hotel has no rate plans', async () => {
+      const hotel = web3.utils.toChecksumAddress(await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION));
+      await request(server)
+        .get(`/hotels/${hotel}/ratePlans`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(404);
+    });
   });
 
   describe('GET /hotels/:hotelAddress/ratePlans/:ratePlanId', () => {
@@ -77,6 +86,15 @@ describe('Rate plans', function () {
     it('should return 404', async () => {
       await request(server)
         .get(`/hotels/${address}/ratePlans/rate-plan-0000`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(404);
+    });
+
+    it('should return 404 if hotel has no rate plans', async () => {
+      const hotel = web3.utils.toChecksumAddress(await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION));
+      await request(server)
+        .get(`/hotels/${hotel}/ratePlans/rate-plan-0000`)
         .set('content-type', 'application/json')
         .set('accept', 'application/json')
         .expect(404);

--- a/test/controllers/room-types.spec.js
+++ b/test/controllers/room-types.spec.js
@@ -118,8 +118,8 @@ describe('Room types', function () {
           expect(res.body).to.have.property('id', 'room-type-1111');
           expect(res.body).to.have.property('availability');
           expect(res.body.availability).to.have.property('updatedAt');
-          expect(res.body.availability).to.have.property('availability');
-          expect(res.body.availability.availability.length).to.be.eql(9);
+          expect(res.body.availability).to.have.nested.property('availability.room-type-1111');
+          expect(res.body.availability.availability['room-type-1111'].length).to.be.eql(9);
         });
     });
 
@@ -202,8 +202,8 @@ describe('Room types', function () {
         .set('accept', 'application/json')
         .expect((res) => {
           expect(res.body).to.have.property('updatedAt');
-          expect(res.body).to.have.property('availability');
-          expect(res.body.availability.length).to.be.eql(9);
+          expect(res.body).to.have.nested.property('availability.room-type-1111');
+          expect(res.body.availability['room-type-1111'].length).to.be.eql(9);
         });
     });
 
@@ -215,8 +215,8 @@ describe('Room types', function () {
         .expect(200)
         .expect((res) => {
           expect(res.body).to.have.property('updatedAt');
-          expect(res.body).to.have.property('availability');
-          expect(res.body.availability.length).to.be.eql(0);
+          expect(res.body).to.have.nested.property('availability.room-type-3333');
+          expect(res.body.availability['room-type-3333'].length).to.be.eql(0);
         });
     });
 

--- a/test/controllers/room-types.spec.js
+++ b/test/controllers/room-types.spec.js
@@ -228,6 +228,15 @@ describe('Room types', function () {
         .expect(404);
     });
 
+    it('should return 404 for a hotel without availability', async () => {
+      const hotel = web3.utils.toChecksumAddress(await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS));
+      await request(server)
+        .get(`/hotels/${hotel}/roomTypes/room-type-2222/availability`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(404);
+    });
+
     it('should return bad gateway for inaccessible data', async () => {
       sinon.stub(wtJsLibsWrapper, 'getWTIndex').resolves({
         getHotel: sinon.stub().resolves(new FakeHotelWithBadOffChainData()),

--- a/test/controllers/room-types.spec.js
+++ b/test/controllers/room-types.spec.js
@@ -63,6 +63,21 @@ describe('Room types', function () {
         });
     });
 
+    it('should include availability if fields is present', async () => {
+      await request(server)
+        .get(`/hotels/${address}/roomTypes?fields=availability`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect((res) => {
+          expect(res.body).to.eql(HOTEL_DESCRIPTION.roomTypes);
+          for (let roomType in res.body) {
+            expect(res.body[roomType]).to.have.property('id');
+            expect(res.body[roomType]).to.have.property('availability');
+          }
+          console.log(res.body);
+        });
+    });
+
     it('should return 404 for non existing hotel', async () => {
       await request(server)
         .get('/hotels/0x0Fd60495d705F4Fb86e1b36Be396757689FbE8B3/roomTypes/room-type-0000')
@@ -179,6 +194,23 @@ describe('Room types', function () {
         .expect(404);
     });
 
+    it('should return 404 for non existing room type', async () => {
+      await request(server)
+        .get(`/hotels/${address}/roomTypes/room-type-0000/ratePlans`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(404);
+    });
+
+    it('should return 404 for a hotel without rate plans', async () => {
+      const hotel = web3.utils.toChecksumAddress(await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION));
+      await request(server)
+        .get(`/hotels/${hotel}/roomTypes/room-type-2222/ratePlans`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(404);
+    });
+
     it('should return bad gateway for inaccessible data', async () => {
       sinon.stub(wtJsLibsWrapper, 'getWTIndex').resolves({
         getHotel: sinon.stub().resolves(new FakeHotelWithBadOffChainData()),
@@ -223,6 +255,14 @@ describe('Room types', function () {
     it('should return 404 for non existing hotel', async () => {
       await request(server)
         .get('/hotels/0x0Fd60495d705F4Fb86e1b36Be396757689FbE8B3/roomTypes/room-type-2222/availability')
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(404);
+    });
+
+    it('should return 404 for non existing room type', async () => {
+      await request(server)
+        .get(`/hotels/${address}/roomTypes/room-type-0000/availability`)
         .set('content-type', 'application/json')
         .set('accept', 'application/json')
         .expect(404);

--- a/test/utils/test-data.js
+++ b/test/utils/test-data.js
@@ -185,7 +185,116 @@ const RATE_PLANS = {
   },
 };
 
+const AVAILABILITY = {
+  'latestSnapshot': {
+    'updatedAt': '2018-07-09T09:22:54.548Z',
+    'availability': {
+      'room-type-1111': [
+        {
+          'date': '2018-07-07',
+          'quantity': 8,
+          'restrictions': {
+            'noArrival': true,
+          },
+        },
+        {
+          'date': '2018-07-08',
+          'quantity': 7,
+          'restrictions': {
+            'noDeparture': true,
+          },
+        },
+        {
+          'date': '2018-07-09',
+          'quantity': 1,
+        },
+        {
+          'date': '2018-07-10',
+          'quantity': 5,
+        },
+        {
+          'date': '2018-07-11',
+          'quantity': 4,
+        },
+        {
+          'date': '2018-07-12',
+          'quantity': 10,
+        },
+        {
+          'date': '2018-07-13',
+          'quantity': 11,
+        },
+        {
+          'date': '2018-07-14',
+          'quantity': 6,
+          'restrictions': {
+            'noArrival': true,
+          },
+        },
+        {
+          'date': '2018-07-15',
+          'quantity': 7,
+          'restrictions': {
+            'noDeparture': true,
+          },
+        },
+      ],
+      'room-type-2222': [
+        {
+          'date': '2018-07-07',
+          'quantity': 2,
+          'restrictions': {
+            'noArrival': true,
+          },
+        },
+        {
+          'date': '2018-07-08',
+          'quantity': 2,
+          'restrictions': {
+            'noDeparture': true,
+          },
+        },
+        {
+          'date': '2018-07-09',
+          'quantity': 2,
+        },
+        {
+          'date': '2018-07-10',
+          'quantity': 1,
+        },
+        {
+          'date': '2018-07-11',
+          'quantity': 0,
+        },
+        {
+          'date': '2018-07-12',
+          'quantity': 0,
+        },
+        {
+          'date': '2018-07-13',
+          'quantity': 0,
+        },
+        {
+          'date': '2018-07-14',
+          'quantity': 0,
+          'restrictions': {
+            'noArrival': true,
+          },
+        },
+        {
+          'date': '2018-07-15',
+          'quantity': 0,
+          'restrictions': {
+            'noDeparture': true,
+          },
+        },
+      ],
+    },
+  },
+};
+
 module.exports = {
   HOTEL_DESCRIPTION,
   RATE_PLANS,
+  AVAILABILITY,
 };


### PR DESCRIPTION
Builds will fail until https://github.com/windingtree/wt-js-libs/pull/191 is released and wt-js-libs is bumped here.

As a followup of https://github.com/windingtree/wiki/issues/55, this adds some availability endpoints to the read API. Swagger for @czervenka  https://app.swaggerhub.com/apis/windingtree/api-for-reading/1.0.2

I have intentionally kept the availability format the same in `roomType/{roomTypeId}/availability` endpoint to make it consistent, because I wanted to keep the `updatedAt` date there. However, on this endpoint, only one key (`roomTypeId`) will be present as opposed to `hotel/{hotelId}/availability` where all room types will be present.

Also, I have pinned the data structure reference to a particular commit to prevent unexpected changes in the spec in the future.