### PR TITLE
feat: Return notificationsUri when requested.

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -55,7 +55,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: fields
           in: query
           description: >
@@ -86,6 +86,7 @@ paths:
                 - managerAddress
                 - updatedAt
                 - cancellationPolicies
+                - notificationsUri
       responses:
         '200':
           description: >-
@@ -113,7 +114,7 @@ paths:
                       Uri to next page of records. When there's no next page,
                       this is not set.
                     $ref: >-
-                      https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/UriType
+                      https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/UriType
         '400':
           $ref: '#/components/responses/InvalidRequestError'
         '500':
@@ -128,7 +129,7 @@ paths:
           description: Hotel Id as returned by `GET /hotel`
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: fields
           required: false
           in: query
@@ -187,7 +188,7 @@ paths:
           description: Hotel Id as returned by `GET /hotel`
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
       responses:
         '200':
           description: Hotel data uris.
@@ -211,7 +212,7 @@ paths:
           description: Hotel Id as returned by `GET /hotel`
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: fields
           in: query
           required: false
@@ -246,14 +247,14 @@ paths:
           description: Hotel Id as returned by `GET /hotel`
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+              https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         - name: roomTypeId
           in: path
           required: true
           description: Id of room type
           schema:
             $ref: >-
-              https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType
+              https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/ObjectIdType
         - name: fields
           in: query
           required: false
@@ -285,13 +286,13 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
         - name: roomTypeId
           in: path
           required: true
           description: Id of room type
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
       responses:
         '200':
           description: Rate plans for the room type
@@ -310,13 +311,13 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
         - name: roomTypeId
           in: path
           required: true
           description: Id of room type
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
       responses:
         '200':
           description: Availability for the room type
@@ -334,7 +335,7 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
       responses:
         '200':
           description: Availability data for the hotel
@@ -352,7 +353,7 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
       responses:
         '200':
           description: Rate plans for the hotel
@@ -370,13 +371,13 @@ paths:
           required: true
           description: Hotel Id as returned by `GET /hotel`
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'        
         - name: ratePlanId
           in: path
           required: true
           description: Id of rate plan
           schema:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
       responses:
         '200':
           description: Rate plan details
@@ -426,27 +427,27 @@ components:
             identifies the errorring record.
     HotelListItem:
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/HotelDescriptionBase'
+        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/HotelDescriptionBase'
         - type: object
           required:
           - id
           properties:
             id:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
             managerAddress:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'    
             roomTypes:
               description: Room types in the hotel
               $ref: '#/components/schemas/RoomTypesResponse'
     HotelDetail:
       allOf:
-      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/HotelDescription'
+      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/HotelDescription'
       - type: object
         properties:
           ratePlans:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/RatePlans'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlans'
           availability: 
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
           roomTypes:
             description: Room types in the hotel
             $ref: '#/components/schemas/RoomTypesResponse'
@@ -458,14 +459,14 @@ components:
         $ref: '#/components/schemas/RoomTypeResponse'
     RoomTypeResponse:
       allOf:
-      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/RoomType'
+      - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RoomType'
       - type: object
         properties:
           id:
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
             description: Vendor room type ID (should be unique for hotel)
           availability: 
-            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
+            $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
               
     RatePlansResponse:
       type: object
@@ -474,31 +475,38 @@ components:
         
     RatePlanResponse:
       allOf:
-        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/RatePlan'
+        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlan'
         - type: object
           properties:
             id:
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/ObjectIdType'
               description: Vendor rate plan ID (should be unique for hotel)
 
     AvailabilityResponse:
-      $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
+      $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/AvailabilitySnapshot'
 
     DataUrisResponse:
+      type: object
       description: Collection of idnetifiers required to look up hotel data
       required:
         - address
         - dataUri
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/HotelDataIndex'
-        - type: object
-          properties:
-            address:
-              description: Ethereum address of the hotel
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
-            dataUri:
-              description: URI of the Hotel data index (pointing off-chain)
-              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/4c6a5bb3ec08784099a2b3e5ad10c07a35701ff7/hotel-data-swagger.yaml#/components/schemas/UriType'
+      properties:
+        address:
+          description: Ethereum address of the hotel
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType'
+        dataUri:
+          description: URI of the Hotel data index (pointing off-chain)
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/UriType'
+        descriptionUri:
+          description: URI of the Hotel data index (pointing off-chain)
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/UriType'
+        ratePlansUri:
+          description: URI of the Hotel data index (pointing off-chain)
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/UriType'
+        availabilityUri:
+          description: URI of the Hotel data index (pointing off-chain)
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/UriType'
 
     Error:
       title: Error

--- a/scripts/local-network.js
+++ b/scripts/local-network.js
@@ -47,6 +47,7 @@ const deployFullHotel = async (offChainDataAdapter, index, hotelDescription, rat
   if (availability) {
     indexFile['availabilityUri'] = await offChainDataAdapter.upload(availability);
   }
+  indexFile.notificationsUri = 'http://notifications.example';
   const dataUri = await offChainDataAdapter.upload(indexFile);
 
   const registerResult = await index.registerHotel(dataUri, {

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -86,6 +86,9 @@ const resolveHotelObject = async (hotel, fields) => {
         ...(flattenObject(plainHotel, fields)),
         id: hotel.address,
       };
+      if (flattenedOffChainData.notificationsUri) {
+        hotelData.notificationsUri = flattenedOffChainData.notificationsUri;
+      }
       if (flattenedOffChainData.ratePlansUri) {
         hotelData.ratePlans = flattenedOffChainData.ratePlansUri;
       }
@@ -136,6 +139,9 @@ const calculateFields = (fieldsQuery) => {
       }
 
       if (firstPart === 'availabilityUri') {
+        return f;
+      }
+      if (firstPart === 'notificationsUri') {
         return f;
       }
 

--- a/test/controllers/hotels.spec.js
+++ b/test/controllers/hotels.spec.js
@@ -190,6 +190,7 @@ describe('Hotels', function () {
         'images',
         'amenities',
         'updatedAt',
+        'notificationsUri',
       ];
       const query = `fields=${fields.join()}`;
 


### PR DESCRIPTION
This reflects the extension of the original data model by notificationsUri.

I have opted for inclusion in hotel data rather than at "/dataUris" because this doesn't really seem like a "data uri" to me. I'm not sure if that's the most natural viewpoint, though.