### PR TITLE
#230 - Gets more permissive wrt DATA_FORMAT_VERSION

### DIFF
--- a/docs/source.yaml
+++ b/docs/source.yaml
@@ -44,11 +44,18 @@ paths:
                   ethNetwork:
                     type: string
                     description: Name of the ethereum network against which this instance runs.
-                  dataFormatVersion:
+                  dataFormatVersions:
                     description: Version number indicating the data format specification version the server expects from hotels.
-                    type: string
-                    format: semver
-                    maxLength: 20
+                    type: object
+                      properties:
+                        airlines:
+                          type: string
+                          format: semver
+                          maxLength: 20
+                        hotels:
+                          type: string
+                          format: semver
+                          maxLength: 20
   /hotels:
     get:
       summary: Lists hotels

--- a/management/local-network.js
+++ b/management/local-network.js
@@ -6,8 +6,6 @@ const WTAirlineIndexContract = require('@windingtree/wt-contracts/build/contract
 const provider = new Web3.providers.HttpProvider('http://localhost:8545');
 const web3 = new Web3(provider);
 
-const { DATA_FORMAT_VERSION } = require('../src/constants');
-
 const getContractWithProvider = (metadata, provider) => {
   let contract = new TruffleContract(metadata);
   contract.setProvider(provider);
@@ -23,7 +21,7 @@ const deployHotelIndex = async () => {
   });
 };
 
-const deployFullHotel = async (offChainDataAdapter, index, hotelDescription, ratePlans, availability, dataFormatVersion) => {
+const deployFullHotel = async (dataFormatVersion, offChainDataAdapter, index, hotelDescription, ratePlans, availability) => {
   const accounts = await web3.eth.getAccounts();
   const indexFile = {};
 
@@ -38,7 +36,7 @@ const deployFullHotel = async (offChainDataAdapter, index, hotelDescription, rat
   }
   indexFile.notificationsUri = 'https://notifications.example';
   indexFile.bookingUri = 'https://booking.example';
-  indexFile.dataFormatVersion = dataFormatVersion || DATA_FORMAT_VERSION;
+  indexFile.dataFormatVersion = dataFormatVersion;
   indexFile.defaultLocale = 'en';
   const dataUri = await offChainDataAdapter.upload(indexFile);
 
@@ -58,7 +56,7 @@ const deployAirlineIndex = async () => {
   });
 };
 
-const deployFullAirline = async (offChainDataAdapter, index, airlineDescription, flights, flightInstances, dataFormatVersion) => {
+const deployFullAirline = async (dataFormatVersion, offChainDataAdapter, index, airlineDescription, flights, flightInstances) => {
   const accounts = await web3.eth.getAccounts();
   const indexFile = {};
 
@@ -75,7 +73,7 @@ const deployFullAirline = async (offChainDataAdapter, index, airlineDescription,
   }
   indexFile.notificationsUri = 'https://notifications.example';
   indexFile.bookingUri = 'https://booking.example';
-  indexFile.dataFormatVersion = dataFormatVersion || DATA_FORMAT_VERSION;
+  indexFile.dataFormatVersion = dataFormatVersion;
   const dataUri = await offChainDataAdapter.upload(indexFile);
 
   const registerResult = await index.registerAirline(dataUri, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,6 +1193,13 @@
         "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "babel-register": {
@@ -5458,6 +5465,13 @@
         "prr": "~1.0.1",
         "semver": "~5.4.1",
         "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        }
       }
     },
     "levn": {
@@ -6229,6 +6243,13 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "npm-run-path": {
@@ -8432,9 +8453,9 @@
       "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
     },
     "send": {
       "version": "0.16.2",
@@ -8783,6 +8804,13 @@
         "require-from-string": "^1.1.0",
         "semver": "^5.3.0",
         "yargs": "^4.7.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "solhint": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash": "^4.17.10",
     "morgan": "^1.9.1",
     "node-fetch": "^2.3.0",
+    "semver": "^6.0.0",
     "swagger-model-validator": "^3.0.5",
     "swagger-ui-express": "^4.0.0",
     "winston": "^3.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,6 @@ const slash = require('express-slash');
 const app = express();
 const { config } = require('./config');
 const {
-  DATA_FORMAT_VERSION,
   AIRLINE_SEGMENT_ID,
   HOTEL_SEGMENT_ID,
   ACCEPTED_SEGMENTS,
@@ -71,7 +70,7 @@ app.get('/', (req, res) => {
     config: process.env.WT_CONFIG,
     wtIndexAddresses: config.wtIndexAddresses,
     ethNetwork: config.ethNetwork,
-    dataFormatVersion: DATA_FORMAT_VERSION,
+    dataFormatVersions: config.dataFormatVersions,
   };
   res.status(200).json(response);
 });

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,10 +1,14 @@
 const winston = require('winston');
+const YAML = require('yamljs');
 const { WtJsLibs } = require('@windingtree/wt-js-libs');
 
 const { ACCEPTED_SEGMENTS } = require('../constants');
+const getSchemaVersion = (packageName) => {
+  let refDef = YAML.load(`node_modules/${packageName}/dist/swagger.yaml`);
+  return refDef.info.version;
+};
 
 const env = process.env.WT_CONFIG || 'dev';
-
 let config = Object.assign({
   port: process.env.PORT || 3000,
   baseUrl: process.env.BASE_URL || 'http://localhost:3000',
@@ -17,6 +21,10 @@ let config = Object.assign({
       }),
     ],
   }),
+  dataFormatVersions: {
+    airlines: getSchemaVersion('@windingtree/wt-airline-schemas'),
+    hotels: getSchemaVersion('@windingtree/wt-hotel-schemas'),
+  },
 }, require(`./${env}`));
 
 // setup js-libs instances

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,11 +1,12 @@
 const winston = require('winston');
 const YAML = require('yamljs');
+const semver = require('semver');
 const { WtJsLibs } = require('@windingtree/wt-js-libs');
 
 const { ACCEPTED_SEGMENTS } = require('../constants');
-const getSchemaVersion = (packageName) => {
+const getPatchForgivingSchemaVersion = (packageName) => {
   let refDef = YAML.load(`node_modules/${packageName}/dist/swagger.yaml`);
-  return refDef.info.version;
+  return `${semver.major(refDef.info.version)}.${semver.minor(refDef.info.version)}.x`;
 };
 
 const env = process.env.WT_CONFIG || 'dev';
@@ -22,8 +23,8 @@ let config = Object.assign({
     ],
   }),
   dataFormatVersions: {
-    airlines: getSchemaVersion('@windingtree/wt-airline-schemas'),
-    hotels: getSchemaVersion('@windingtree/wt-hotel-schemas'),
+    airlines: getPatchForgivingSchemaVersion('@windingtree/wt-airline-schemas'),
+    hotels: getPatchForgivingSchemaVersion('@windingtree/wt-hotel-schemas'),
   },
 }, require(`./${env}`));
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -74,8 +74,9 @@ const AIRLINE_DESCRIPTION_FIELDS = [
 const DEFAULT_PAGE_SIZE = 30;
 const MAX_PAGE_SIZE = 300;
 
-const DATA_FORMAT_VERSION = '0.6.0';
 const SCHEMA_PATH = 'docs/swagger.yaml';
+const VALIDATION_WARNING_HEADER = 'x-data-validation-warning';
+
 const HOTEL_SCHEMA_MODEL = 'HotelDetail';
 const AIRLINE_SCHEMA_MODEL = 'AirlineDetail';
 const ROOM_TYPE_MODEL = 'windingtree-wt-hotel-schemas-RoomType';
@@ -83,7 +84,6 @@ const RATE_PLAN_MODEL = 'windingtree-wt-hotel-schemas-RatePlan';
 const AVAILABILITY_MODEL = 'windingtree-wt-hotel-schemas-AvailabilityForDay';
 const FLIGHT_MODEL = 'windingtree-wt-airline-schemas-Flight';
 const FLIGHT_INSTANCE_MODEL = 'windingtree-wt-airline-schemas-FlightInstance';
-const VALIDATION_WARNING_HEADER = 'x-data-validation-warning';
 
 const HOTEL_SEGMENT_ID = 'hotels';
 const AIRLINE_SEGMENT_ID = 'airlines';
@@ -100,7 +100,6 @@ module.exports = {
   DEFAULT_AIRLINE_FIELDS,
   DEFAULT_PAGE_SIZE,
   MAX_PAGE_SIZE,
-  DATA_FORMAT_VERSION,
   SCHEMA_PATH,
   HOTEL_SCHEMA_MODEL,
   AIRLINE_SCHEMA_MODEL,

--- a/src/controllers/airlines.js
+++ b/src/controllers/airlines.js
@@ -1,6 +1,6 @@
 const { errors: wtJsLibsErrors } = require('@windingtree/wt-js-libs');
 const { flattenObject, formatError } = require('../services/utils');
-const { baseUrl } = require('../config').config;
+const { config } = require('../config');
 const { DataFormatValidator } = require('../services/validation');
 const {
   HttpValidationError,
@@ -140,7 +140,15 @@ const fillAirlineList = async (path, fields, airlines, limit, startWith) => {
   for (let airline of items) {
     try {
       resolvedAirlineObject = await resolveAirlineObject(airline, fields.toFlatten, fields.onChain);
-      DataFormatValidator.validate(resolvedAirlineObject, 'airline', AIRLINE_SCHEMA_MODEL, swaggerDocument.components.schemas, undefined, fields.mapped);
+      DataFormatValidator.validate(
+        resolvedAirlineObject,
+        AIRLINE_SCHEMA_MODEL,
+        swaggerDocument.components.schemas,
+        config.dataFormatVersions.airlines,
+        undefined,
+        'airline',
+        fields.mapped,
+      );
       delete resolvedAirlineObject.dataFormatVersion;
       realItems.push(resolvedAirlineObject);
     } catch (e) {
@@ -161,7 +169,7 @@ const fillAirlineList = async (path, fields, airlines, limit, startWith) => {
       }
     }
   }
-  let next = nextStart ? `${baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nextStart}` : undefined;
+  let next = nextStart ? `${config.baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nextStart}` : undefined;
 
   if (realErrors.length && realItems.length < limit && nextStart) {
     const nestedResult = await fillAirlineList(path, fields, airlines, limit - realItems.length, nextStart);
@@ -169,7 +177,7 @@ const fillAirlineList = async (path, fields, airlines, limit, startWith) => {
     warningItems = warningItems.concat(nestedResult.warnings);
     realErrors = realErrors.concat(nestedResult.errors);
     if (realItems.length && nestedResult.nextStart) {
-      next = `${baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nestedResult.nextStart}`;
+      next = `${config.baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nestedResult.nextStart}`;
     } else {
       next = undefined;
     }
@@ -215,7 +223,15 @@ const find = async (req, res, next) => {
       if (resolvedAirline.error) {
         return next(new HttpBadGatewayError('airlineNotAccessible', resolvedAirline.error, 'Airline data is not accessible.'));
       }
-      DataFormatValidator.validate(resolvedAirline, 'airline', AIRLINE_SCHEMA_MODEL, swaggerDocument.components.schemas, undefined, fields.mapped);
+      DataFormatValidator.validate(
+        resolvedAirline,
+        AIRLINE_SCHEMA_MODEL,
+        swaggerDocument.components.schemas,
+        config.dataFormatVersions.airlines,
+        undefined,
+        'airline',
+        fields.mapped
+      );
       delete resolvedAirline.dataFormatVersion;
     } catch (e) {
       if (e instanceof HttpValidationError) {

--- a/src/controllers/availability.js
+++ b/src/controllers/availability.js
@@ -1,6 +1,7 @@
 const { Http404Error, HttpValidationError } = require('../errors');
 const { DataFormatValidator } = require('../services/validation');
 const { formatError } = require('../services/utils');
+const { config } = require('../config');
 const {
   SCHEMA_PATH,
   AVAILABILITY_MODEL,
@@ -14,10 +15,17 @@ const findAll = async (req, res, next) => {
     }
     let availability = plainHotel.dataUri.contents.availabilityUri.contents;
     const items = [], warnings = [], errors = [];
-    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, AVAILABILITY_MODEL, undefined, {});
+    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, AVAILABILITY_MODEL);
     for (let roomType of availability.roomTypes) {
       try {
-        DataFormatValidator.validate(roomType, 'availability', AVAILABILITY_MODEL, swaggerDocument.components.schemas, plainHotel.dataUri.contents.dataFormatVersion);
+        DataFormatValidator.validate(
+          roomType,
+          AVAILABILITY_MODEL,
+          swaggerDocument.components.schemas,
+          config.dataFormatVersions.hotels,
+          plainHotel.dataUri.contents.dataFormatVersion,
+          'availability'
+        );
         items.push(roomType);
       } catch (e) {
         if (e instanceof HttpValidationError) {

--- a/src/controllers/flight-instances.js
+++ b/src/controllers/flight-instances.js
@@ -1,6 +1,7 @@
 const { Http404Error, HttpValidationError } = require('../errors');
 const { DataFormatValidator } = require('../services/validation');
 const { formatError } = require('../services/utils');
+const { config } = require('../config');
 const {
   VALIDATION_WARNING_HEADER,
   SCHEMA_PATH,
@@ -23,10 +24,16 @@ const find = async (req, res, next) => {
     if (!flightInstance) {
       return next(new Http404Error('flightInstanceNotFound', 'Flight instance not found'));
     }
-    flightInstance.dataFormatVersion = plainAirline.dataUri.contents.dataFormatVersion;
-    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, FLIGHT_INSTANCE_MODEL, undefined, {});
+    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, FLIGHT_INSTANCE_MODEL);
     try {
-      DataFormatValidator.validate(flightInstance, 'flight instance', FLIGHT_INSTANCE_MODEL, swaggerDocument.components.schemas);
+      DataFormatValidator.validate(
+        flightInstance,
+        FLIGHT_INSTANCE_MODEL,
+        swaggerDocument.components.schemas,
+        config.dataFormatVersions.airlines,
+        plainAirline.dataUri.contents.dataFormatVersion,
+        'flight instance',
+      );
     } catch (e) {
       if (e instanceof HttpValidationError) {
         let err = formatError(e);
@@ -59,10 +66,17 @@ const findAll = async (req, res, next) => {
       return next(new Http404Error('flightNotFound', 'Flight not found'));
     }
     const instances = [], warnings = [], errors = [];
-    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, FLIGHT_INSTANCE_MODEL, undefined, {});
+    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, FLIGHT_INSTANCE_MODEL);
     for (let instance of flight.flightInstancesUri.contents) {
       try {
-        DataFormatValidator.validate(instance, 'flight instance', FLIGHT_INSTANCE_MODEL, swaggerDocument.components.schemas, plainAirline.dataUri.contents.dataFormatVersion);
+        DataFormatValidator.validate(
+          instance,
+          FLIGHT_INSTANCE_MODEL,
+          swaggerDocument.components.schemas,
+          config.dataFormatVersions.airlines,
+          plainAirline.dataUri.contents.dataFormatVersion,
+          'flight instance',
+        );
         instances.push(instance);
       } catch (e) {
         if (e instanceof HttpValidationError) {

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -1,6 +1,6 @@
 const { errors: wtJsLibsErrors } = require('@windingtree/wt-js-libs');
 const { flattenObject, formatError } = require('../services/utils');
-const { baseUrl } = require('../config').config;
+const { config } = require('../config');
 const { DataFormatValidator } = require('../services/validation');
 const {
   HttpValidationError,
@@ -121,7 +121,15 @@ const fillHotelList = async (path, fields, hotels, limit, startWith) => {
   for (let hotel of items) {
     try {
       resolvedHotelObject = await resolveHotelObject(hotel, fields.toFlatten, fields.onChain);
-      DataFormatValidator.validate(resolvedHotelObject, 'hotel', HOTEL_SCHEMA_MODEL, swaggerDocument.components.schemas, undefined, fields.mapped);
+      DataFormatValidator.validate(
+        resolvedHotelObject,
+        HOTEL_SCHEMA_MODEL,
+        swaggerDocument.components.schemas,
+        config.dataFormatVersions.hotels,
+        undefined,
+        'hotel',
+        fields.mapped
+      );
       delete resolvedHotelObject.dataFormatVersion;
       realItems.push(resolvedHotelObject);
     } catch (e) {
@@ -142,7 +150,7 @@ const fillHotelList = async (path, fields, hotels, limit, startWith) => {
       }
     }
   }
-  let next = nextStart ? `${baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nextStart}` : undefined;
+  let next = nextStart ? `${config.baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nextStart}` : undefined;
 
   if (realErrors.length && realItems.length < limit && nextStart) {
     const nestedResult = await fillHotelList(path, fields, hotels, limit - realItems.length, nextStart);
@@ -150,7 +158,7 @@ const fillHotelList = async (path, fields, hotels, limit, startWith) => {
     warningItems = warningItems.concat(nestedResult.warnings);
     realErrors = realErrors.concat(nestedResult.errors);
     if (realItems.length && nestedResult.nextStart) {
-      next = `${baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nestedResult.nextStart}`;
+      next = `${config.baseUrl}${path}?limit=${limit}&fields=${fields.mapped.join(',')}&startWith=${nestedResult.nextStart}`;
     } else {
       next = undefined;
     }
@@ -196,7 +204,15 @@ const find = async (req, res, next) => {
       if (resolvedHotel.error) {
         return next(new HttpBadGatewayError('hotelNotAccessible', resolvedHotel.error, 'Hotel data is not accessible.'));
       }
-      DataFormatValidator.validate(resolvedHotel, 'hotel', HOTEL_SCHEMA_MODEL, swaggerDocument.components.schemas, undefined, fields.mapped);
+      DataFormatValidator.validate(
+        resolvedHotel,
+        HOTEL_SCHEMA_MODEL,
+        swaggerDocument.components.schemas,
+        config.dataFormatVersions.hotels,
+        undefined,
+        'hotel',
+        fields.mapped
+      );
       delete resolvedHotel.dataFormatVersion;
     } catch (e) {
       if (e instanceof HttpValidationError) {

--- a/src/controllers/room-types.js
+++ b/src/controllers/room-types.js
@@ -1,6 +1,7 @@
 const { Http404Error, HttpValidationError } = require('../errors');
 const { DataFormatValidator } = require('../services/validation');
 const { formatError } = require('../services/utils');
+const { config } = require('../config');
 const {
   VALIDATION_WARNING_HEADER,
   SCHEMA_PATH,
@@ -64,11 +65,18 @@ const findAll = async (req, res, next) => {
     const plainHotel = await getPlainHotel(res.locals.wt.hotel, fieldsArray);
     let roomTypes = plainHotel.dataUri.contents.descriptionUri.contents.roomTypes;
     const items = [], warnings = [], errors = [];
-    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, ROOM_TYPE_MODEL, undefined, {});
+    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, ROOM_TYPE_MODEL);
     for (let roomType of roomTypes) {
       roomType = setAdditionalFields(roomType, plainHotel, fieldsQuery);
       try {
-        DataFormatValidator.validate(roomType, 'room type', ROOM_TYPE_MODEL, swaggerDocument.components.schemas, plainHotel.dataUri.contents.dataFormatVersion);
+        DataFormatValidator.validate(
+          roomType,
+          ROOM_TYPE_MODEL,
+          swaggerDocument.components.schemas,
+          config.dataFormatVersions.hotels,
+          plainHotel.dataUri.contents.dataFormatVersion,
+          'room type'
+        );
         items.push(roomType);
       } catch (e) {
         if (e instanceof HttpValidationError) {
@@ -107,10 +115,16 @@ const find = async (req, res, next) => {
       return next(new Http404Error('roomTypeNotFound', 'Room type not found'));
     }
     roomType = setAdditionalFields(roomType, plainHotel, fieldsQuery);
-    roomType.dataFormatVersion = plainHotel.dataUri.contents.dataFormatVersion;
-    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, ROOM_TYPE_MODEL, fieldsArray.length === 0 ? undefined : fieldsArray, {});
+    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, ROOM_TYPE_MODEL, fieldsArray.length === 0 ? undefined : fieldsArray);
     try {
-      DataFormatValidator.validate(roomType, 'room type', ROOM_TYPE_MODEL, swaggerDocument.components.schemas);
+      DataFormatValidator.validate(
+        roomType,
+        ROOM_TYPE_MODEL,
+        swaggerDocument.components.schemas,
+        config.dataFormatVersions.hotels,
+        plainHotel.dataUri.contents.dataFormatVersion,
+        'room type'
+      );
     } catch (e) {
       if (e instanceof HttpValidationError) {
         let err = formatError(e);
@@ -145,10 +159,17 @@ const findRatePlans = async (req, res, next) => {
     }
     const ratePlans = detectRatePlans(roomTypeId, plainHotel.dataUri.contents.ratePlansUri.contents);
     const items = [], warnings = [], errors = [];
-    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, RATE_PLAN_MODEL, undefined, {});
+    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, RATE_PLAN_MODEL);
     for (let plan of ratePlans) {
       try {
-        DataFormatValidator.validate(plan, 'rate plan', RATE_PLAN_MODEL, swaggerDocument.components.schemas, plainHotel.dataUri.contents.dataFormatVersion);
+        DataFormatValidator.validate(
+          plan,
+          RATE_PLAN_MODEL,
+          swaggerDocument.components.schemas,
+          config.dataFormatVersions.hotels,
+          plainHotel.dataUri.contents.dataFormatVersion,
+          'rate plan',
+        );
         items.push(plan);
       } catch (e) {
         if (e instanceof HttpValidationError) {
@@ -190,10 +211,17 @@ const findAvailability = async (req, res, next) => {
     }
     const availability = detectAvailability(roomTypeId, plainHotel.dataUri.contents.availabilityUri.contents);
     let items = [], warnings = [], errors = [];
-    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, AVAILABILITY_MODEL, undefined, {});
+    const swaggerDocument = await DataFormatValidator.loadSchemaFromPath(SCHEMA_PATH, AVAILABILITY_MODEL);
     for (let roomType of availability.roomTypes) {
       try {
-        DataFormatValidator.validate(roomType, 'availability', AVAILABILITY_MODEL, swaggerDocument.components.schemas, plainHotel.dataUri.contents.dataFormatVersion);
+        DataFormatValidator.validate(
+          roomType,
+          AVAILABILITY_MODEL,
+          swaggerDocument.components.schemas,
+          config.dataFormatVersions.hotels,
+          plainHotel.dataUri.contents.dataFormatVersion,
+          'availability',
+        );
         items.push(roomType);
       } catch (e) {
         if (e instanceof HttpValidationError) {

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -9,8 +9,8 @@ const {
   MisconfigurationError,
 } = require('../errors');
 const {
-  DATA_FORMAT_VERSION,
-} = require('../constants');
+  config,
+} = require('../config');
 
 /**
  * Utility class for data format validation.
@@ -19,16 +19,18 @@ class DataFormatValidator {
   /**
    * Static method to validate data against specific model in schema.
    * @param data
-   * @param type
    * @param modelName
    * @param schemas The components.schemas part of swagger definition
-   * @param dataFormatVersion If the data doesn't contain `dataFormatVersion` field, you may provide a value here.
+   * @param desiredDataFormatVersion Version range that the declared data format version is checked
+   * @param declaredDataFormatVersion If the data doesn't contain `dataFormatVersion` field, you may provide an overriding value here.
+   * @param type human-readable name that is used in error messages
    * @param fields Fields to resolve
    */
-  static validate (data, type, modelName, schemas, dataFormatVersion, fields) {
+  static validate (data, modelName, schemas, desiredDataFormatVersion, declaredDataFormatVersion = undefined, type = 'model', fields = []) {
+    let dataFormatVersion = declaredDataFormatVersion;
     // don't validate dataFormatVersion when only fetching on-chain data
-    if (!fields || !(fields.length === 1 && fields[0] === 'id')) {
-      dataFormatVersion = data.dataFormatVersion || dataFormatVersion;
+    if (!fields || !fields.length || !(fields.length === 1 && fields[0] === 'id')) {
+      dataFormatVersion = data.dataFormatVersion || declaredDataFormatVersion;
       if (!dataFormatVersion) {
         const error = new HttpValidationError();
         error.data = {
@@ -40,11 +42,12 @@ class DataFormatValidator {
         };
         throw error;
       }
-      if (DATA_FORMAT_VERSION !== dataFormatVersion) {
+      // TODO desired should be a semverrange
+      if (desiredDataFormatVersion !== dataFormatVersion) {
         const error = new HttpValidationError();
         error.data = {
           valid: true,
-          errors: [`Unsupported data format version ${data.dataFormatVersion}. Supported versions: ${DATA_FORMAT_VERSION}`],
+          errors: [`Unsupported data format version ${dataFormatVersion}. Supported versions: ${desiredDataFormatVersion}`],
           data: {
             id: data.id || (data.data && data.data.id),
           },
@@ -73,9 +76,9 @@ class DataFormatValidator {
    * @param fieldsMapping
    * @returns {Promise<String>}
    */
-  static async loadSchemaFromPath (schemaPath, schemaModel, fields, fieldsMapping) {
-    if (!DATA_FORMAT_VERSION) {
-      throw new MisconfigurationError('Constant DATA_FORMAT_VERSION is not configured, check API deployment.');
+  static async loadSchemaFromPath (schemaPath, schemaModel, fields = undefined, fieldsMapping = {}) {
+    if (!config.dataFormatVersions) {
+      throw new MisconfigurationError('config.dataFormatVersions is not configured, check API deployment.');
     }
     let mainSchemaDocument;
     if (DataFormatValidator.CACHE.hasOwnProperty(schemaPath)) {
@@ -136,7 +139,7 @@ class DataFormatValidator {
    * @returns {*} Updated schemas definition
    * @private
    */
-  static _intersectRequiredFields (data, modelName, fields, reversedFieldMapping) {
+  static _intersectRequiredFields (data, modelName, fields = undefined, reversedFieldMapping = {}) {
     let nestedBaseFields = {};
     if (fields) {
       for (let field of fields) {

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch');
 const path = require('path');
 const YAML = require('yamljs');
+const semver = require('semver');
 const _ = require('lodash');
 const Validator = require('swagger-model-validator');
 
@@ -42,8 +43,7 @@ class DataFormatValidator {
         };
         throw error;
       }
-      // TODO desired should be a semverrange
-      if (desiredDataFormatVersion !== dataFormatVersion) {
+      if (!semver.satisfies(dataFormatVersion, desiredDataFormatVersion)) {
         const error = new HttpValidationError();
         error.data = {
           valid: true,

--- a/test/controllers/airlines.spec.js
+++ b/test/controllers/airlines.spec.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const sinon = require('sinon');
 const request = require('supertest');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
-const { config } = require('../../src/config');
+const { getSchemaVersion } = require('../utils/schemas');
 const {
   deployAirlineIndex,
   deployFullAirline,
@@ -46,8 +46,8 @@ describe('Airlines', function () {
 
   describe('GET /airlines', () => {
     beforeEach(async () => {
-      airline0address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
-      airline1address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      airline0address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      airline1address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
     });
 
     it('should return default fields for airlines list', async () => {
@@ -471,7 +471,7 @@ describe('Airlines', function () {
   describe('GET /airlines/:airlineAddress', () => {
     let address;
     beforeEach(async () => {
-      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
     });
 
     it('should return default fields for airline detail', async () => {
@@ -506,10 +506,23 @@ describe('Airlines', function () {
         });
     });
 
+    it('should not return validation warning when data differs in patch version', async () => {
+      let dataFormatVersion = '0.6.0';
+      address = await deployFullAirline(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      await request(server)
+        .get(`/airlines/${address}`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(200)
+        .expect((res) => {
+          expect(res.headers).to.not.have.property(VALIDATION_WARNING_HEADER);
+        });
+    });
+
     it('should return validation errors for default field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       airlineDescription.code = 23;
-      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}`)
         .set('content-type', 'application/json')
@@ -523,7 +536,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing default field', async () => {
       let airlineDescription = Object.assign({}, AIRLINE_DESCRIPTION);
       delete airlineDescription.code;
-      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}`)
         .set('content-type', 'application/json')
@@ -537,7 +550,7 @@ describe('Airlines', function () {
     it('should return validation errors for non-default field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       airlineDescription.updatedAt = false;
-      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}?fields=updatedAt`)
         .set('content-type', 'application/json')
@@ -551,7 +564,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing non-default field', async () => {
       let airlineDescription = Object.assign({}, AIRLINE_DESCRIPTION);
       delete airlineDescription.defaultCancellationAmount;
-      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}?fields=defaultCancellationAmount`)
         .set('content-type', 'application/json')
@@ -565,7 +578,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing value in nested field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       delete airlineDescription.contacts.general;
-      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}`)
         .set('content-type', 'application/json')
@@ -579,7 +592,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing nested exact field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       delete airlineDescription.contacts.general;
-      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}?fields=contacts.general`)
         .set('content-type', 'application/json')
@@ -823,7 +836,7 @@ describe('Airlines', function () {
 
   describe('GET /airlines/:airlineAddress/meta', () => {
     it('should return all fields', async () => {
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/meta`)
         .set('content-type', 'application/json')
@@ -833,7 +846,7 @@ describe('Airlines', function () {
           expect(res.body).to.have.property('dataUri');
           expect(res.body).to.have.property('descriptionUri');
           expect(res.body).to.have.property('flightsUri');
-          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.airlines);
+          expect(res.body).to.have.property('dataFormatVersion', getSchemaVersion('@windingtree/wt-airline-schemas'));
           expect(res.body.dataUri).to.match(/^in-memory:\/\//);
           expect(res.body.descriptionUri).to.match(/^in-memory:\/\//);
           expect(res.body.flightsUri).to.match(/^in-memory:\/\//);
@@ -842,7 +855,7 @@ describe('Airlines', function () {
     });
 
     it('should not return unspecified optional fields', async () => {
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       await request(server)
         .get(`/airlines/${airline}/meta`)
         .set('content-type', 'application/json')
@@ -851,7 +864,7 @@ describe('Airlines', function () {
           expect(res.body).to.have.property('address', airline);
           expect(res.body).to.have.property('dataUri');
           expect(res.body).to.have.property('descriptionUri');
-          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.airlines);
+          expect(res.body).to.have.property('dataFormatVersion', getSchemaVersion('@windingtree/wt-airline-schemas'));
           expect(res.body).to.not.have.property('flightsUri');
         })
         .expect(200);

--- a/test/controllers/airlines.spec.js
+++ b/test/controllers/airlines.spec.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const sinon = require('sinon');
 const request = require('supertest');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
-const { AIRLINE_SEGMENT_ID, DATA_FORMAT_VERSION } = require('../../src/constants');
+const { config } = require('../../src/config');
 const {
   deployAirlineIndex,
   deployFullAirline,
@@ -16,6 +16,7 @@ const {
   FLIGHT_INSTANCES,
 } = require('../utils/test-data');
 const {
+  AIRLINE_SEGMENT_ID,
   DEFAULT_PAGE_SIZE,
   VALIDATION_WARNING_HEADER,
 } = require('../../src/constants');
@@ -45,8 +46,8 @@ describe('Airlines', function () {
 
   describe('GET /airlines', () => {
     beforeEach(async () => {
-      airline0address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
-      airline1address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      airline0address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      airline1address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
     });
 
     it('should return default fields for airlines list', async () => {
@@ -470,7 +471,7 @@ describe('Airlines', function () {
   describe('GET /airlines/:airlineAddress', () => {
     let address;
     beforeEach(async () => {
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
     });
 
     it('should return default fields for airline detail', async () => {
@@ -493,7 +494,7 @@ describe('Airlines', function () {
 
     it('should return validation warning for unsupported version', async () => {
       let dataFormatVersion = '0.1.0';
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES, dataFormatVersion);
+      address = await deployFullAirline(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}`)
         .set('content-type', 'application/json')
@@ -508,7 +509,7 @@ describe('Airlines', function () {
     it('should return validation errors for default field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       airlineDescription.code = 23;
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}`)
         .set('content-type', 'application/json')
@@ -522,7 +523,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing default field', async () => {
       let airlineDescription = Object.assign({}, AIRLINE_DESCRIPTION);
       delete airlineDescription.code;
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}`)
         .set('content-type', 'application/json')
@@ -536,7 +537,7 @@ describe('Airlines', function () {
     it('should return validation errors for non-default field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       airlineDescription.updatedAt = false;
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}?fields=updatedAt`)
         .set('content-type', 'application/json')
@@ -550,7 +551,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing non-default field', async () => {
       let airlineDescription = Object.assign({}, AIRLINE_DESCRIPTION);
       delete airlineDescription.defaultCancellationAmount;
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}?fields=defaultCancellationAmount`)
         .set('content-type', 'application/json')
@@ -564,7 +565,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing value in nested field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       delete airlineDescription.contacts.general;
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}`)
         .set('content-type', 'application/json')
@@ -578,7 +579,7 @@ describe('Airlines', function () {
     it('should return validation errors for missing nested exact field', async () => {
       let airlineDescription = _.cloneDeep(AIRLINE_DESCRIPTION);
       delete airlineDescription.contacts.general;
-      address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, airlineDescription, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${address}?fields=contacts.general`)
         .set('content-type', 'application/json')
@@ -822,7 +823,7 @@ describe('Airlines', function () {
 
   describe('GET /airlines/:airlineAddress/meta', () => {
     it('should return all fields', async () => {
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/meta`)
         .set('content-type', 'application/json')
@@ -832,7 +833,7 @@ describe('Airlines', function () {
           expect(res.body).to.have.property('dataUri');
           expect(res.body).to.have.property('descriptionUri');
           expect(res.body).to.have.property('flightsUri');
-          expect(res.body).to.have.property('dataFormatVersion', DATA_FORMAT_VERSION);
+          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.airlines);
           expect(res.body.dataUri).to.match(/^in-memory:\/\//);
           expect(res.body.descriptionUri).to.match(/^in-memory:\/\//);
           expect(res.body.flightsUri).to.match(/^in-memory:\/\//);
@@ -841,7 +842,7 @@ describe('Airlines', function () {
     });
 
     it('should not return unspecified optional fields', async () => {
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       await request(server)
         .get(`/airlines/${airline}/meta`)
         .set('content-type', 'application/json')
@@ -850,7 +851,7 @@ describe('Airlines', function () {
           expect(res.body).to.have.property('address', airline);
           expect(res.body).to.have.property('dataUri');
           expect(res.body).to.have.property('descriptionUri');
-          expect(res.body).to.have.property('dataFormatVersion');
+          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.airlines);
           expect(res.body).to.not.have.property('flightsUri');
         })
         .expect(200);

--- a/test/controllers/availability.spec.js
+++ b/test/controllers/availability.spec.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
-const { config } = require('../../src/config');
+const { getSchemaVersion } = require('../utils/schemas');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
 const { HOTEL_SEGMENT_ID } = require('../../src/constants');
 const {
@@ -29,7 +29,7 @@ describe('Availability', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(HOTEL_SEGMENT_ID);
     indexContract = await deployHotelIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, HOTEL_SEGMENT_ID);
-    address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+    address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
   });
 
   afterEach(() => {
@@ -87,7 +87,7 @@ describe('Availability', function () {
     it('should return error for invalid data', async () => {
       let availability = _.cloneDeep(AVAILABILITY);
       delete availability.roomTypes[0].date;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
       await request(server)
         .get(`/hotels/${hotel}/availability`)
         .set('content-type', 'application/json')
@@ -103,7 +103,7 @@ describe('Availability', function () {
     });
 
     it('should return 404 if hotel has no availability', async () => {
-      let hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      let hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
       await request(server)
         .get(`/hotels/${hotel}/availability`)
         .set('content-type', 'application/json')

--- a/test/controllers/availability.spec.js
+++ b/test/controllers/availability.spec.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
+const { config } = require('../../src/config');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
 const { HOTEL_SEGMENT_ID } = require('../../src/constants');
 const {
@@ -28,7 +29,7 @@ describe('Availability', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(HOTEL_SEGMENT_ID);
     indexContract = await deployHotelIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, HOTEL_SEGMENT_ID);
-    address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+    address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
   });
 
   afterEach(() => {
@@ -68,7 +69,7 @@ describe('Availability', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      const hotel = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/availability`)
         .set('content-type', 'application/json')
@@ -86,7 +87,7 @@ describe('Availability', function () {
     it('should return error for invalid data', async () => {
       let availability = _.cloneDeep(AVAILABILITY);
       delete availability.roomTypes[0].date;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
       await request(server)
         .get(`/hotels/${hotel}/availability`)
         .set('content-type', 'application/json')
@@ -102,7 +103,7 @@ describe('Availability', function () {
     });
 
     it('should return 404 if hotel has no availability', async () => {
-      let hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      let hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
       await request(server)
         .get(`/hotels/${hotel}/availability`)
         .set('content-type', 'application/json')

--- a/test/controllers/flight-instances.spec.js
+++ b/test/controllers/flight-instances.spec.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
+const { config } = require('../../src/config');
 const { AIRLINE_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
   deployAirlineIndex,
@@ -28,7 +29,7 @@ describe('Flight instances', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(AIRLINE_SEGMENT_ID);
     indexContract = await deployAirlineIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, AIRLINE_SEGMENT_ID);
-    address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+    address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
   });
 
   afterEach(() => {
@@ -59,7 +60,7 @@ describe('Flight instances', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES, dataFormatVersion);
+      const airline = await deployFullAirline(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights/${flightId}/instances`)
         .set('content-type', 'application/json')
@@ -77,7 +78,7 @@ describe('Flight instances', function () {
     it('should return error for invalid data', async () => {
       let flightInstances = _.cloneDeep(FLIGHT_INSTANCES);
       delete flightInstances[0].bookingClasses;
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
       await request(server)
         .get(`/airlines/${airline}/flights/${flightId}/instances`)
         .set('content-type', 'application/json')
@@ -133,7 +134,7 @@ describe('Flight instances', function () {
     });
 
     it('should return 404 if airline has no flight instances', async () => {
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       const flightInstanceId = 'flight-instance-0000';
       const flightId = 'IeKeix6G';
       await request(server)
@@ -161,7 +162,7 @@ describe('Flight instances', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES, dataFormatVersion);
+      const airline = await deployFullAirline(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights/IeKeix6G/instances/IeKeix6G-1`)
         .set('content-type', 'application/json')
@@ -176,7 +177,7 @@ describe('Flight instances', function () {
     it('should return error for invalid data', async () => {
       let flightInstances = _.cloneDeep(FLIGHT_INSTANCES);
       delete flightInstances[0].segments;
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
       await request(server)
         .get(`/airlines/${airline}/flights/IeKeix6G/instances/IeKeix6G-1`)
         .set('content-type', 'application/json')

--- a/test/controllers/flight-instances.spec.js
+++ b/test/controllers/flight-instances.spec.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
-const { config } = require('../../src/config');
+const { getSchemaVersion } = require('../utils/schemas');
 const { AIRLINE_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
   deployAirlineIndex,
@@ -29,7 +29,7 @@ describe('Flight instances', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(AIRLINE_SEGMENT_ID);
     indexContract = await deployAirlineIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, AIRLINE_SEGMENT_ID);
-    address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+    address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
   });
 
   afterEach(() => {
@@ -78,7 +78,7 @@ describe('Flight instances', function () {
     it('should return error for invalid data', async () => {
       let flightInstances = _.cloneDeep(FLIGHT_INSTANCES);
       delete flightInstances[0].bookingClasses;
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
       await request(server)
         .get(`/airlines/${airline}/flights/${flightId}/instances`)
         .set('content-type', 'application/json')
@@ -134,7 +134,7 @@ describe('Flight instances', function () {
     });
 
     it('should return 404 if airline has no flight instances', async () => {
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       const flightInstanceId = 'flight-instance-0000';
       const flightId = 'IeKeix6G';
       await request(server)
@@ -177,7 +177,7 @@ describe('Flight instances', function () {
     it('should return error for invalid data', async () => {
       let flightInstances = _.cloneDeep(FLIGHT_INSTANCES);
       delete flightInstances[0].segments;
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, flightInstances);
       await request(server)
         .get(`/airlines/${airline}/flights/IeKeix6G/instances/IeKeix6G-1`)
         .set('content-type', 'application/json')

--- a/test/controllers/flights.spec.js
+++ b/test/controllers/flights.spec.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
-const { config } = require('../../src/config');
+const { getSchemaVersion } = require('../utils/schemas');
 const { AIRLINE_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
   deployAirlineIndex,
@@ -25,7 +25,7 @@ describe('Flights', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(AIRLINE_SEGMENT_ID);
     indexContract = await deployAirlineIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, AIRLINE_SEGMENT_ID);
-    address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+    address = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
   });
 
   afterEach(() => {
@@ -102,7 +102,7 @@ describe('Flights', function () {
     it('should return error for invalid data', async () => {
       let airlineFlights = _.cloneDeep(AIRLINE_FLIGHTS);
       delete airlineFlights.items[0].origin;
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights`)
         .set('content-type', 'application/json')
@@ -127,7 +127,7 @@ describe('Flights', function () {
     });
 
     it('should return 404 if airline has no flights', async () => {
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       await request(server)
         .get(`/airlines/${airline}/flights`)
         .set('content-type', 'application/json')
@@ -211,7 +211,7 @@ describe('Flights', function () {
     });
 
     it('should return 404 if airline has no flights', async () => {
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       const flightId = 'IeKeix6G';
       await request(server)
         .get(`/airlines/${airline}/flights/${flightId}`)
@@ -237,7 +237,7 @@ describe('Flights', function () {
     it('should return error for invalid data', async () => {
       let airlineFlights = _.cloneDeep(AIRLINE_FLIGHTS);
       delete airlineFlights.items[0].segments;
-      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
+      const airline = await deployFullAirline(getSchemaVersion('@windingtree/wt-airline-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights/IeKeix6G`)
         .set('content-type', 'application/json')

--- a/test/controllers/flights.spec.js
+++ b/test/controllers/flights.spec.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
+const { config } = require('../../src/config');
 const { AIRLINE_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
   deployAirlineIndex,
@@ -24,7 +25,7 @@ describe('Flights', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(AIRLINE_SEGMENT_ID);
     indexContract = await deployAirlineIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, AIRLINE_SEGMENT_ID);
-    address = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
+    address = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
   });
 
   afterEach(() => {
@@ -83,7 +84,7 @@ describe('Flights', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES, dataFormatVersion);
+      const airline = await deployFullAirline(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights`)
         .set('content-type', 'application/json')
@@ -101,7 +102,7 @@ describe('Flights', function () {
     it('should return error for invalid data', async () => {
       let airlineFlights = _.cloneDeep(AIRLINE_FLIGHTS);
       delete airlineFlights.items[0].origin;
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights`)
         .set('content-type', 'application/json')
@@ -126,7 +127,7 @@ describe('Flights', function () {
     });
 
     it('should return 404 if airline has no flights', async () => {
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       await request(server)
         .get(`/airlines/${airline}/flights`)
         .set('content-type', 'application/json')
@@ -210,7 +211,7 @@ describe('Flights', function () {
     });
 
     it('should return 404 if airline has no flights', async () => {
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION);
       const flightId = 'IeKeix6G';
       await request(server)
         .get(`/airlines/${airline}/flights/${flightId}`)
@@ -221,7 +222,7 @@ describe('Flights', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES, dataFormatVersion);
+      const airline = await deployFullAirline(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, AIRLINE_FLIGHTS, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights/IeKeix6G`)
         .set('content-type', 'application/json')
@@ -236,7 +237,7 @@ describe('Flights', function () {
     it('should return error for invalid data', async () => {
       let airlineFlights = _.cloneDeep(AIRLINE_FLIGHTS);
       delete airlineFlights.items[0].segments;
-      const airline = await deployFullAirline(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
+      const airline = await deployFullAirline(config.dataFormatVersions.airlines, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, AIRLINE_DESCRIPTION, airlineFlights, FLIGHT_INSTANCES);
       await request(server)
         .get(`/airlines/${airline}/flights/IeKeix6G`)
         .set('content-type', 'application/json')

--- a/test/controllers/hotels.spec.js
+++ b/test/controllers/hotels.spec.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const sinon = require('sinon');
 const request = require('supertest');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
-const { config } = require('../../src/config');
+const { getSchemaVersion } = require('../utils/schemas');
 const {
   deployHotelIndex,
   deployFullHotel,
@@ -45,8 +45,8 @@ describe('Hotels', function () {
 
   describe('GET /hotels', () => {
     beforeEach(async () => {
-      hotel0address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
-      hotel1address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      hotel0address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      hotel1address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
     });
 
     it('should enforce strict routing', async () => {
@@ -399,7 +399,7 @@ describe('Hotels', function () {
   describe('GET /hotels/:hotelAddress', () => {
     let address;
     beforeEach(async () => {
-      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
     });
 
     it('should return default fields for hotel detail', async () => {
@@ -439,10 +439,23 @@ describe('Hotels', function () {
         });
     });
 
+    it('should not return validation warning when data differs in patch version', async () => {
+      let dataFormatVersion = '0.6.0';
+      address = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+      await request(server)
+        .get(`/hotels/${address}`)
+        .set('content-type', 'application/json')
+        .set('accept', 'application/json')
+        .expect(200)
+        .expect((res) => {
+          expect(res.headers).to.not.have.property(VALIDATION_WARNING_HEADER);
+        });
+    });
+
     it('should return validation errors for default field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       hotelDescription.description = 23;
-      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}`)
         .set('content-type', 'application/json')
@@ -456,7 +469,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing default field', async () => {
       let hotelDescription = Object.assign({}, HOTEL_DESCRIPTION);
       delete hotelDescription.description;
-      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}`)
         .set('content-type', 'application/json')
@@ -470,7 +483,7 @@ describe('Hotels', function () {
     it('should return validation errors for non-default field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       hotelDescription.timezone = false;
-      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}?fields=timezone`)
         .set('content-type', 'application/json')
@@ -484,7 +497,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing non-default field', async () => {
       let hotelDescription = Object.assign({}, HOTEL_DESCRIPTION);
       delete hotelDescription.defaultCancellationAmount;
-      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}?fields=defaultCancellationAmount`)
         .set('content-type', 'application/json')
@@ -498,7 +511,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing value in nested field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.location.latitude;
-      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}`)
         .set('content-type', 'application/json')
@@ -512,7 +525,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing nested exact field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.location.latitude;
-      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}?fields=location.latitude`)
         .set('content-type', 'application/json')
@@ -754,7 +767,7 @@ describe('Hotels', function () {
 
   describe('GET /hotels/:hotelAddress/meta', () => {
     it('should return all fields', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/meta`)
         .set('content-type', 'application/json')
@@ -765,7 +778,7 @@ describe('Hotels', function () {
           expect(res.body).to.have.property('descriptionUri');
           expect(res.body).to.have.property('ratePlansUri');
           expect(res.body).to.have.property('availabilityUri');
-          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.hotels);
+          expect(res.body).to.have.property('dataFormatVersion', getSchemaVersion('@windingtree/wt-hotel-schemas'));
           expect(res.body).to.have.property('defaultLocale', 'en');
           expect(res.body.dataUri).to.match(/^in-memory:\/\//);
           expect(res.body.descriptionUri).to.match(/^in-memory:\/\//);
@@ -776,7 +789,7 @@ describe('Hotels', function () {
     });
 
     it('should not return unspecified optional fields', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/meta`)
         .set('content-type', 'application/json')
@@ -785,7 +798,7 @@ describe('Hotels', function () {
           expect(res.body).to.have.property('address', hotel);
           expect(res.body).to.have.property('dataUri');
           expect(res.body).to.have.property('descriptionUri');
-          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.hotels);
+          expect(res.body).to.have.property('dataFormatVersion', getSchemaVersion('@windingtree/wt-hotel-schemas'));
           expect(res.body).to.not.have.property('ratePlansUri');
           expect(res.body).to.not.have.property('availabilityUri');
           expect(res.body).to.have.property('defaultLocale', 'en');

--- a/test/controllers/hotels.spec.js
+++ b/test/controllers/hotels.spec.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const sinon = require('sinon');
 const request = require('supertest');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
-const { HOTEL_SEGMENT_ID, DATA_FORMAT_VERSION } = require('../../src/constants');
+const { config } = require('../../src/config');
 const {
   deployHotelIndex,
   deployFullHotel,
@@ -16,6 +16,7 @@ const {
   AVAILABILITY,
 } = require('../utils/test-data');
 const {
+  HOTEL_SEGMENT_ID,
   DEFAULT_PAGE_SIZE,
   VALIDATION_WARNING_HEADER,
 } = require('../../src/constants');
@@ -44,8 +45,8 @@ describe('Hotels', function () {
 
   describe('GET /hotels', () => {
     beforeEach(async () => {
-      hotel0address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
-      hotel1address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      hotel0address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      hotel1address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
     });
 
     it('should enforce strict routing', async () => {
@@ -398,7 +399,7 @@ describe('Hotels', function () {
   describe('GET /hotels/:hotelAddress', () => {
     let address;
     beforeEach(async () => {
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
     });
 
     it('should return default fields for hotel detail', async () => {
@@ -426,7 +427,7 @@ describe('Hotels', function () {
 
     it('should return validation warning for unsupported version', async () => {
       let dataFormatVersion = '0.1.0';
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      address = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}`)
         .set('content-type', 'application/json')
@@ -441,7 +442,7 @@ describe('Hotels', function () {
     it('should return validation errors for default field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       hotelDescription.description = 23;
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}`)
         .set('content-type', 'application/json')
@@ -455,7 +456,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing default field', async () => {
       let hotelDescription = Object.assign({}, HOTEL_DESCRIPTION);
       delete hotelDescription.description;
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}`)
         .set('content-type', 'application/json')
@@ -469,7 +470,7 @@ describe('Hotels', function () {
     it('should return validation errors for non-default field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       hotelDescription.timezone = false;
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}?fields=timezone`)
         .set('content-type', 'application/json')
@@ -483,7 +484,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing non-default field', async () => {
       let hotelDescription = Object.assign({}, HOTEL_DESCRIPTION);
       delete hotelDescription.defaultCancellationAmount;
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}?fields=defaultCancellationAmount`)
         .set('content-type', 'application/json')
@@ -497,7 +498,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing value in nested field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.location.latitude;
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}`)
         .set('content-type', 'application/json')
@@ -511,7 +512,7 @@ describe('Hotels', function () {
     it('should return validation errors for missing nested exact field', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.location.latitude;
-      address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${address}?fields=location.latitude`)
         .set('content-type', 'application/json')
@@ -753,7 +754,7 @@ describe('Hotels', function () {
 
   describe('GET /hotels/:hotelAddress/meta', () => {
     it('should return all fields', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/meta`)
         .set('content-type', 'application/json')
@@ -764,7 +765,7 @@ describe('Hotels', function () {
           expect(res.body).to.have.property('descriptionUri');
           expect(res.body).to.have.property('ratePlansUri');
           expect(res.body).to.have.property('availabilityUri');
-          expect(res.body).to.have.property('dataFormatVersion', DATA_FORMAT_VERSION);
+          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.hotels);
           expect(res.body).to.have.property('defaultLocale', 'en');
           expect(res.body.dataUri).to.match(/^in-memory:\/\//);
           expect(res.body.descriptionUri).to.match(/^in-memory:\/\//);
@@ -775,7 +776,7 @@ describe('Hotels', function () {
     });
 
     it('should not return unspecified optional fields', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/meta`)
         .set('content-type', 'application/json')
@@ -784,7 +785,7 @@ describe('Hotels', function () {
           expect(res.body).to.have.property('address', hotel);
           expect(res.body).to.have.property('dataUri');
           expect(res.body).to.have.property('descriptionUri');
-          expect(res.body).to.have.property('dataFormatVersion');
+          expect(res.body).to.have.property('dataFormatVersion', config.dataFormatVersions.hotels);
           expect(res.body).to.not.have.property('ratePlansUri');
           expect(res.body).to.not.have.property('availabilityUri');
           expect(res.body).to.have.property('defaultLocale', 'en');

--- a/test/controllers/rate-plans.spec.js
+++ b/test/controllers/rate-plans.spec.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
+const { config } = require('../../src/config');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
 const { HOTEL_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
@@ -28,7 +29,7 @@ describe('Rate plans', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(HOTEL_SEGMENT_ID);
     indexContract = await deployHotelIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, HOTEL_SEGMENT_ID);
-    address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+    address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
   });
 
   afterEach(() => {
@@ -66,7 +67,7 @@ describe('Rate plans', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      const hotel = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans`)
         .set('content-type', 'application/json')
@@ -84,7 +85,7 @@ describe('Rate plans', function () {
     it('should return error for invalid data', async () => {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].price;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans`)
         .set('content-type', 'application/json')
@@ -100,7 +101,7 @@ describe('Rate plans', function () {
     });
 
     it('should return 404 if hotel has no rate plans', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans`)
         .set('content-type', 'application/json')
@@ -137,7 +138,7 @@ describe('Rate plans', function () {
     });
 
     it('should return 404 if hotel has no rate plans', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans/rate-plan-0000`)
         .set('content-type', 'application/json')
@@ -161,7 +162,7 @@ describe('Rate plans', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      const hotel = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans/rate-plan-1`)
         .set('content-type', 'application/json')
@@ -177,7 +178,7 @@ describe('Rate plans', function () {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].roomTypeIds;
       delete ratePlans[0].price;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans/rate-plan-1`)
         .set('content-type', 'application/json')
@@ -192,7 +193,7 @@ describe('Rate plans', function () {
     it('should return error for invalid nested data', async () => {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].modifiers[0].unit;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans/rate-plan-1`)
         .set('content-type', 'application/json')

--- a/test/controllers/rate-plans.spec.js
+++ b/test/controllers/rate-plans.spec.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
-const { config } = require('../../src/config');
+const { getSchemaVersion } = require('../utils/schemas');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
 const { HOTEL_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
@@ -29,7 +29,7 @@ describe('Rate plans', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(HOTEL_SEGMENT_ID);
     indexContract = await deployHotelIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, HOTEL_SEGMENT_ID);
-    address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+    address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
   });
 
   afterEach(() => {
@@ -85,7 +85,7 @@ describe('Rate plans', function () {
     it('should return error for invalid data', async () => {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].price;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans`)
         .set('content-type', 'application/json')
@@ -101,7 +101,7 @@ describe('Rate plans', function () {
     });
 
     it('should return 404 if hotel has no rate plans', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans`)
         .set('content-type', 'application/json')
@@ -138,7 +138,7 @@ describe('Rate plans', function () {
     });
 
     it('should return 404 if hotel has no rate plans', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans/rate-plan-0000`)
         .set('content-type', 'application/json')
@@ -178,7 +178,7 @@ describe('Rate plans', function () {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].roomTypeIds;
       delete ratePlans[0].price;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans/rate-plan-1`)
         .set('content-type', 'application/json')
@@ -193,7 +193,7 @@ describe('Rate plans', function () {
     it('should return error for invalid nested data', async () => {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].modifiers[0].unit;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/ratePlans/rate-plan-1`)
         .set('content-type', 'application/json')

--- a/test/controllers/room-types.spec.js
+++ b/test/controllers/room-types.spec.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
+const { config } = require('../../src/config');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
 const { HOTEL_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
@@ -39,7 +40,7 @@ describe('Room types', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(HOTEL_SEGMENT_ID);
     indexContract = await deployHotelIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, HOTEL_SEGMENT_ID);
-    address = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+    address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
   });
 
   afterEach(() => {
@@ -121,7 +122,7 @@ describe('Room types', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      const hotel = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes`)
         .set('content-type', 'application/json')
@@ -139,7 +140,7 @@ describe('Room types', function () {
     it('should return error for invalid data', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.roomTypes[0].occupancy.max;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes`)
         .set('content-type', 'application/json')
@@ -223,7 +224,7 @@ describe('Room types', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      const hotel = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111`)
         .set('content-type', 'application/json')
@@ -239,7 +240,7 @@ describe('Room types', function () {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.roomTypes[0].name;
       delete hotelDescription.roomTypes[0].occupancy;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111`)
         .set('content-type', 'application/json')
@@ -252,7 +253,7 @@ describe('Room types', function () {
     });
 
     it('should return empty ratePlans if hotel does not have ratePlansUri', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111?fields=ratePlans`)
         .set('content-type', 'application/json')
@@ -280,7 +281,7 @@ describe('Room types', function () {
     });
 
     it('should return empty availability if hotel does not have ratePlansUri', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111?fields=availability`)
         .set('content-type', 'application/json')
@@ -342,7 +343,7 @@ describe('Room types', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      const hotel = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111/ratePlans`)
         .set('content-type', 'application/json')
@@ -360,7 +361,7 @@ describe('Room types', function () {
     it('should return error for invalid data', async () => {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].price;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111/ratePlans`)
         .set('content-type', 'application/json')
@@ -392,7 +393,7 @@ describe('Room types', function () {
     });
 
     it('should return 404 for a hotel without rate plans', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-2222/ratePlans`)
         .set('content-type', 'application/json')
@@ -448,7 +449,7 @@ describe('Room types', function () {
 
     it('should return warning for old data format version', async () => {
       let dataFormatVersion = '0.1.0';
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY, dataFormatVersion);
+      const hotel = await deployFullHotel(dataFormatVersion, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111/availability`)
         .set('content-type', 'application/json')
@@ -466,7 +467,7 @@ describe('Room types', function () {
     it('should return error for invalid data', async () => {
       let availability = _.cloneDeep(AVAILABILITY);
       delete availability.roomTypes[0].date;
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111/availability`)
         .set('content-type', 'application/json')
@@ -498,7 +499,7 @@ describe('Room types', function () {
     });
 
     it('should return 404 for a hotel without availability', async () => {
-      const hotel = await deployFullHotel(await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-2222/availability`)
         .set('content-type', 'application/json')

--- a/test/controllers/room-types.spec.js
+++ b/test/controllers/room-types.spec.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { expect } = require('chai');
 const request = require('supertest');
 const sinon = require('sinon');
-const { config } = require('../../src/config');
+const { getSchemaVersion } = require('../utils/schemas');
 const wtJsLibsWrapper = require('../../src/services/wt-js-libs');
 const { HOTEL_SEGMENT_ID, VALIDATION_WARNING_HEADER } = require('../../src/constants');
 const {
@@ -40,7 +40,7 @@ describe('Room types', function () {
     wtLibsInstance = wtJsLibsWrapper.getInstance(HOTEL_SEGMENT_ID);
     indexContract = await deployHotelIndex();
     wtJsLibsWrapper._setIndexAddress(indexContract.address, HOTEL_SEGMENT_ID);
-    address = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
+    address = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, AVAILABILITY);
   });
 
   afterEach(() => {
@@ -140,7 +140,7 @@ describe('Room types', function () {
     it('should return error for invalid data', async () => {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.roomTypes[0].occupancy.max;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes`)
         .set('content-type', 'application/json')
@@ -240,7 +240,7 @@ describe('Room types', function () {
       let hotelDescription = _.cloneDeep(HOTEL_DESCRIPTION);
       delete hotelDescription.roomTypes[0].name;
       delete hotelDescription.roomTypes[0].occupancy;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, hotelDescription, RATE_PLANS, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111`)
         .set('content-type', 'application/json')
@@ -253,7 +253,7 @@ describe('Room types', function () {
     });
 
     it('should return empty ratePlans if hotel does not have ratePlansUri', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111?fields=ratePlans`)
         .set('content-type', 'application/json')
@@ -281,7 +281,7 @@ describe('Room types', function () {
     });
 
     it('should return empty availability if hotel does not have ratePlansUri', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111?fields=availability`)
         .set('content-type', 'application/json')
@@ -361,7 +361,7 @@ describe('Room types', function () {
     it('should return error for invalid data', async () => {
       let ratePlans = _.cloneDeep(RATE_PLANS);
       delete ratePlans[0].price;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, ratePlans, AVAILABILITY);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111/ratePlans`)
         .set('content-type', 'application/json')
@@ -393,7 +393,7 @@ describe('Room types', function () {
     });
 
     it('should return 404 for a hotel without rate plans', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-2222/ratePlans`)
         .set('content-type', 'application/json')
@@ -467,7 +467,7 @@ describe('Room types', function () {
     it('should return error for invalid data', async () => {
       let availability = _.cloneDeep(AVAILABILITY);
       delete availability.roomTypes[0].date;
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS, availability);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-1111/availability`)
         .set('content-type', 'application/json')
@@ -499,7 +499,7 @@ describe('Room types', function () {
     });
 
     it('should return 404 for a hotel without availability', async () => {
-      const hotel = await deployFullHotel(config.dataFormatVersions.hotels, await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
+      const hotel = await deployFullHotel(getSchemaVersion('@windingtree/wt-hotel-schemas'), await wtLibsInstance.getOffChainDataClient('in-memory'), indexContract, HOTEL_DESCRIPTION, RATE_PLANS);
       await request(server)
         .get(`/hotels/${hotel}/roomTypes/room-type-2222/availability`)
         .set('content-type', 'application/json')

--- a/test/utils/fake-airlines.js
+++ b/test/utils/fake-airlines.js
@@ -15,7 +15,7 @@ let fakeAirlineCounter = 1;
 class FakeNiceAirline {
   constructor () {
     this.address = `nice-airline-${fakeAirlineCounter++}`;
-    this.dataFormatVersion = '0.6.0';
+    this.dataFormatVersion = '0.6.6';
     this.descriptionUri = `nice-airline-uri-${fakeAirlineCounter++}`;
   }
   get dataIndex () {

--- a/test/utils/fake-airlines.js
+++ b/test/utils/fake-airlines.js
@@ -1,4 +1,5 @@
 const { errors: wtJsLibsErrors } = require('@windingtree/wt-js-libs');
+const { getSchemaVersion } = require('./schemas');
 
 /**
  * Usage:
@@ -15,7 +16,8 @@ let fakeAirlineCounter = 1;
 class FakeNiceAirline {
   constructor () {
     this.address = `nice-airline-${fakeAirlineCounter++}`;
-    this.dataFormatVersion = '0.6.6';
+    this.dataFormatVersion = getSchemaVersion('@windingtree/wt-airline-schemas');
+    this.dataFormatVersion = getSchemaVersion('@windingtree/wt-airline-schemas');
     this.descriptionUri = `nice-airline-uri-${fakeAirlineCounter++}`;
   }
   get dataIndex () {

--- a/test/utils/fake-hotels.js
+++ b/test/utils/fake-hotels.js
@@ -1,4 +1,5 @@
 const { errors: wtJsLibsErrors } = require('@windingtree/wt-js-libs');
+const { getSchemaVersion } = require('./schemas');
 
 /**
  * Usage:
@@ -15,7 +16,7 @@ let fakeHotelCounter = 1;
 class FakeNiceHotel {
   constructor () {
     this.address = `nice-hotel-${fakeHotelCounter}`;
-    this.dataFormatVersion = '0.6.6';
+    this.dataFormatVersion = getSchemaVersion('@windingtree/wt-hotel-schemas');
     this.descriptionUri = `nice-hotel-uri-${fakeHotelCounter++}`;
   }
   get dataIndex () {

--- a/test/utils/fake-hotels.js
+++ b/test/utils/fake-hotels.js
@@ -15,7 +15,7 @@ let fakeHotelCounter = 1;
 class FakeNiceHotel {
   constructor () {
     this.address = `nice-hotel-${fakeHotelCounter}`;
-    this.dataFormatVersion = '0.6.0';
+    this.dataFormatVersion = '0.6.6';
     this.descriptionUri = `nice-hotel-uri-${fakeHotelCounter++}`;
   }
   get dataIndex () {

--- a/test/utils/schemas.js
+++ b/test/utils/schemas.js
@@ -1,0 +1,15 @@
+const YAML = require('yamljs');
+
+const _cache = {};
+
+const getSchemaVersion = (packageName) => {
+  if (!_cache[packageName]) {
+    let refDef = YAML.load(`node_modules/${packageName}/dist/swagger.yaml`);
+    _cache[packageName] = refDef.info.version;
+  }
+  return _cache[packageName];
+};
+
+module.exports = {
+  getSchemaVersion,
+};


### PR DESCRIPTION
Changes:

1. Declares two `dataFormatVersion` fields on root endpoint - one for hotels, one for airlines.
1. Both `dataFormatVersion` fields are taken from linked data-schemas packages but altered so that we support any patch version (it's not ideal, but a step forward)
1. The validator now uses semver comparison

In the future, the validator should get some more refactoring, because there seems to be a lot of repeating code in various places. Also, the patch level robustness is probably not enough and the system should become much more forgiving in the future (which also requires some refactoring of the validator).